### PR TITLE
tag_malloc and tag_free

### DIFF
--- a/thrust/detail/tag_malloc_and_free.h
+++ b/thrust/detail/tag_malloc_and_free.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <thrust/detail/malloc_and_free_adl_helper.h>
+#include <thrust/system/detail/generic/select_system.h>
+#include <thrust/system/detail/generic/memory.h>
+
+namespace thrust {
+namespace detail {
+template<typename Tag>
+void* tag_malloc(Tag, size_t cnt) {
+    using thrust::system::detail::generic::select_system;
+    using thrust::system::detail::generic::malloc;
+    return malloc(select_system(Tag()), cnt);
+}
+
+template<typename Tag>
+void tag_free(Tag, void* p) {
+    using thrust::system::detail::generic::select_system;
+    using thrust::system::detail::generic::free;
+    return free(select_system(Tag()), p);
+}
+}
+}


### PR DESCRIPTION
I'm sure you have your own ideas about what the interface should look like for a thrust::malloc and thrust::free (in other words, I'm not offended if you don't accept this patch). Here's something that worked for me.
