### PR TITLE
KNOWN_FAIL TestForEachLargeRegisterFootprint on sm_1x

### DIFF
--- a/testing/backend/cuda/for_each.cu
+++ b/testing/backend/cuda/for_each.cu
@@ -1,0 +1,61 @@
+#include <unittest/unittest.h>
+#include <thrust/for_each.h>
+
+static const size_t NUM_REGISTERS = 100;
+
+template <size_t N> __host__ __device__ void f   (int * x) { int temp = *x; f<N - 1>(x + 1); *x = temp;};
+template <>         __host__ __device__ void f<0>(int * x) { }
+template <size_t N>
+struct CopyFunctorWithManyRegisters
+{
+  __host__ __device__
+  void operator()(int * ptr)
+  {
+      f<N>(ptr);
+  }
+};
+
+
+void TestForEachLargeRegisterFootprint()
+{
+  // XXX this test fails with "too many resources requested for launch" on sm_1x GPUs with CUDA 4.2
+  int current_device = -1;
+  cudaGetDevice(&current_device);
+  cudaDeviceProp prop;
+  cudaGetDeviceProperties(&prop, current_device);
+
+  if(prop.major < 2)
+  {
+    KNOWN_FAILURE;
+  }
+
+  thrust::device_vector<int> data(NUM_REGISTERS, 12345);
+
+  thrust::device_vector<int *> input(1, thrust::raw_pointer_cast(&data[0])); // length is irrelevant
+  
+  thrust::for_each(input.begin(), input.end(), CopyFunctorWithManyRegisters<NUM_REGISTERS>());
+}
+DECLARE_UNITTEST(TestForEachLargeRegisterFootprint);
+
+
+void TestForEachNLargeRegisterFootprint()
+{
+  // XXX this test fails with "too many resources requested for launch" on sm_1x GPUs with CUDA 4.2
+  int current_device = -1;
+  cudaGetDevice(&current_device);
+  cudaDeviceProp prop;
+  cudaGetDeviceProperties(&prop, current_device);
+
+  if(prop.major < 2)
+  {
+    KNOWN_FAILURE;
+  }
+
+  thrust::device_vector<int> data(NUM_REGISTERS, 12345);
+
+  thrust::device_vector<int *> input(1, thrust::raw_pointer_cast(&data[0])); // length is irrelevant
+  
+  thrust::for_each_n(input.begin(), input.size(), CopyFunctorWithManyRegisters<NUM_REGISTERS>());
+}
+DECLARE_UNITTEST(TestForEachNLargeRegisterFootprint);
+

--- a/testing/for_each.cu
+++ b/testing/for_each.cu
@@ -218,45 +218,6 @@ void TestForEachN(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestForEachN);
 
 
-template <size_t N> __host__ __device__ void f   (int * x) { int temp = *x; f<N - 1>(x + 1); *x = temp;};
-template <>         __host__ __device__ void f<0>(int * x) { }
-template <size_t N>
-struct CopyFunctorWithManyRegisters
-{
-    __host__ __device__
-    void operator()(int * ptr)
-    {
-        f<N>(ptr);
-    }
-};
-
-
-void TestForEachLargeRegisterFootprint()
-{
-    const size_t N = 100;
-
-    thrust::device_vector<int> data(N, 12345);
-
-    thrust::device_vector<int *> input(1, thrust::raw_pointer_cast(&data[0])); // length is irrelevant
-    
-    thrust::for_each(input.begin(), input.end(), CopyFunctorWithManyRegisters<N>());
-}
-DECLARE_UNITTEST(TestForEachLargeRegisterFootprint);
-
-
-void TestForEachNLargeRegisterFootprint()
-{
-    const size_t N = 100;
-
-    thrust::device_vector<int> data(N, 12345);
-
-    thrust::device_vector<int *> input(1, thrust::raw_pointer_cast(&data[0])); // length is irrelevant
-    
-    thrust::for_each_n(input.begin(), input.size(), CopyFunctorWithManyRegisters<N>());
-}
-DECLARE_UNITTEST(TestForEachNLargeRegisterFootprint);
-
-
 template <typename T, unsigned int N>
 struct SetFixedVectorToConstant
 {


### PR DESCRIPTION
Move the for_each tests which validate we can run kernels with a large register footprint to testing/backend/cuda/for_each.cu

Mark TestForEachLargeRegisterFootprint and TestForEachNLargeRegisterFootprint as KNOWN_FAILUREs for sm_1x GPUs.
