### PR TITLE
Allow the arch= command line variable to take a list of values.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -278,7 +278,11 @@ def cc_compiler_flags(CXX, mode, host_backend, device_backend, warn_all, warning
 
 def nv_compiler_flags(mode, device_backend, arch):
   """Returns a list of command line flags specific to nvcc"""
-  result = ['-arch=' + arch]
+  result = []
+  for machine_arch in arch:
+    # transform arch_XX to compute_XX
+    virtual_arch = machine_arch.replace('sm','compute')
+    result.append('-gencode="arch={0},code={1}"'.format(virtual_arch, virtual_arch))
   if mode == 'debug':
     # turn on debug mode
     # XXX make this work when we've debugged nvcc -G
@@ -308,8 +312,8 @@ def command_line_variables():
                         allowed_values = ('release', 'debug')))
   
   # add a variable to handle compute capability
-  vars.Add(EnumVariable('arch', 'Compute capability code generation', 'sm_10',
-                        allowed_values = ('sm_10', 'sm_11', 'sm_12', 'sm_13', 'sm_20', 'sm_21')))
+  vars.Add(ListVariable('arch', 'Compute capability code generation', 'sm_10',
+                        ['sm_10', 'sm_11', 'sm_12', 'sm_13', 'sm_20', 'sm_21']))
   
   # add a variable to handle warnings
   # only enable Wall by default on compilers other than cl


### PR DESCRIPTION
Allow the arch= command line variable to take a list of values.
Implement it with -gencode instead of -arch.

Fixes #164
