### PR TITLE
Add an alias "unit_tests" which simply builds the unit tester program

### DIFF
--- a/testing/SConscript
+++ b/testing/SConscript
@@ -43,11 +43,14 @@ sources = filter(test_filter, sources)
 
 tester = my_env.Program('tester', sources)
 
-# add the tester to the 'run_unit_tests' alias
-tester_alias = my_env.Alias('run_unit_tests', [tester], tester[0].abspath)
+# create a 'unit_tests' alias
+unit_tests_alias = my_env.Alias('unit_tests', [tester])
 
-# always build the 'run_tests' target whether or not it needs it
-my_env.AlwaysBuild(tester_alias)
+# add the tester to the 'run_unit_tests' alias
+run_unit_tests_alias = my_env.Alias('run_unit_tests', [tester], tester[0].abspath)
+
+# always build the 'run_unit_tests' target whether or not it needs it
+my_env.AlwaysBuild(run_unit_tests_alias)
 
 # add the unit tests alias to the 'run_tests' alias
 my_env.Alias('run_tests', [tester], tester[0].abspath)


### PR DESCRIPTION
Add an alias "unit_tests" which simply builds the unit tester program
(without having to specify the full path to the target).

Fixes #163
