### PR TITLE
Eliminate superfluous reinterpret_tag overload

### DIFF
--- a/thrust/iterator/detail/retag.h
+++ b/thrust/iterator/detail/retag.h
@@ -117,10 +117,10 @@ template<typename Tag, typename T, typename OtherTag>
     Tag,
     thrust::pointer<T,Tag>
   >::type
-    reinterpret_tag(thrust::pointer<T,OtherTag> ptr)
+    retag(thrust::pointer<T,OtherTag> ptr)
 {
   return reinterpret_tag<Tag>(ptr);
-} // end reinterpret_tag()
+} // end retag()
 
 
 // avoid deeply-nested tagged_iterator


### PR DESCRIPTION
Reported by Bryan Catanzaro

Fixes #186
