### PR TITLE
Guard access to global state with __CUDA_ARCH__ in testing/allocator.cu

### DIFF
--- a/testing/allocator.cu
+++ b/testing/allocator.cu
@@ -62,7 +62,9 @@ struct my_allocator_with_custom_destroy
   __host__ __device__
   void destroy(T *p)
   {
+#if !__CUDA_ARCH__
     g_state = 13;
+#endif
   }
 };
 


### PR DESCRIPTION
Fixes #210
