### PR TITLE
Add __host__ __device__ decorators to prevent CUDA 5 warnings.

### DIFF
--- a/thrust/detail/swap.h
+++ b/thrust/detail/swap.h
@@ -23,6 +23,7 @@ namespace thrust
 {
 
 template<typename Assignable1, typename Assignable2>
+__host__ __device__
   void swap(Assignable1 &a, Assignable2 &b)
 {
   Assignable1 temp = a;

--- a/thrust/iterator/iterator_facade.h
+++ b/thrust/iterator/iterator_facade.h
@@ -61,36 +61,42 @@ class iterator_core_access
     // iterator comparisons are our friends
     template <ITERATOR_FACADE_FORMAL_PARMS_I(1),
               ITERATOR_FACADE_FORMAL_PARMS_I(2)>
+    __host__ __device__
     friend bool
     operator ==(iterator_facade<ITERATOR_FACADE_ARGS_I(1)> const& lhs,
                 iterator_facade<ITERATOR_FACADE_ARGS_I(2)> const& rhs);
 
     template <ITERATOR_FACADE_FORMAL_PARMS_I(1),
               ITERATOR_FACADE_FORMAL_PARMS_I(2)>
+    __host__ __device__
     friend bool
     operator !=(iterator_facade<ITERATOR_FACADE_ARGS_I(1)> const& lhs,
                 iterator_facade<ITERATOR_FACADE_ARGS_I(2)> const& rhs);
 
     template <ITERATOR_FACADE_FORMAL_PARMS_I(1),
               ITERATOR_FACADE_FORMAL_PARMS_I(2)>
+    __host__ __device__
     friend bool
     operator <(iterator_facade<ITERATOR_FACADE_ARGS_I(1)> const& lhs,
                iterator_facade<ITERATOR_FACADE_ARGS_I(2)> const& rhs);
 
     template <ITERATOR_FACADE_FORMAL_PARMS_I(1),
               ITERATOR_FACADE_FORMAL_PARMS_I(2)>
+    __host__ __device__
     friend bool
     operator >(iterator_facade<ITERATOR_FACADE_ARGS_I(1)> const& lhs,
                iterator_facade<ITERATOR_FACADE_ARGS_I(2)> const& rhs);
 
     template <ITERATOR_FACADE_FORMAL_PARMS_I(1),
               ITERATOR_FACADE_FORMAL_PARMS_I(2)>
+    __host__ __device__
     friend bool
     operator <=(iterator_facade<ITERATOR_FACADE_ARGS_I(1)> const& lhs,
                 iterator_facade<ITERATOR_FACADE_ARGS_I(2)> const& rhs);
 
     template <ITERATOR_FACADE_FORMAL_PARMS_I(1),
               ITERATOR_FACADE_FORMAL_PARMS_I(2)>
+    __host__ __device__
     friend bool
     operator >=(iterator_facade<ITERATOR_FACADE_ARGS_I(1)> const& lhs,
                 iterator_facade<ITERATOR_FACADE_ARGS_I(2)> const& rhs);
@@ -98,6 +104,7 @@ class iterator_core_access
     // iterator difference is our friend
     template <ITERATOR_FACADE_FORMAL_PARMS_I(1),
               ITERATOR_FACADE_FORMAL_PARMS_I(2)>
+    __host__ __device__
     friend
       typename thrust::detail::distance_from_result<
         iterator_facade<ITERATOR_FACADE_ARGS_I(1)>,


### PR DESCRIPTION
CUDA 5 is more strict about certain host/device warnings.  This commit silences the following warnings:

```
/home/bcatanzaro/thrust/thrust/iterator/iterator_facade.h(326): warning: a __host__ function("thrust::experimental::operator==") redeclared with __host__ __device__, hence treated as a __host__ __device__ function

/home/bcatanzaro/thrust/thrust/iterator/iterator_facade.h(340): warning: a __host__ function("thrust::experimental::operator!=") redeclared with __host__ __device__, hence treated as a __host__ __device__ function

/home/bcatanzaro/thrust/thrust/iterator/iterator_facade.h(354): warning: a __host__ function("thrust::experimental::operator<") redeclared with __host__ __device__, hence treated as a __host__ __device__ function

/home/bcatanzaro/thrust/thrust/iterator/iterator_facade.h(368): warning: a __host__ function("thrust::experimental::operator>") redeclared with __host__ __device__, hence treated as a __host__ __device__ function

/home/bcatanzaro/thrust/thrust/iterator/iterator_facade.h(382): warning: a __host__ function("thrust::experimental::operator<=") redeclared with __host__ __device__, hence treated as a __host__ __device__ function

/home/bcatanzaro/thrust/thrust/iterator/iterator_facade.h(396): warning: a __host__ function("thrust::experimental::operator>=") redeclared with __host__ __device__, hence treated as a __host__ __device__ function

/home/bcatanzaro/thrust/thrust/iterator/iterator_facade.h(415): warning: a __host__ function("thrust::experimental::operator-") redeclared with __host__ __device__, hence treated as a __host__ __device__ function

/home/bcatanzaro/thrust/thrust/swap.h(66): warning: a __host__ function("thrust::swap") redeclared with __host__ __device__, hence treated as a __host__ __device__ function
```
