### PR TITLE
has_member_construct1 -> needs_default_construct_via_allocator

### DIFF
--- a/thrust/detail/allocator/default_construct_range.inl
+++ b/thrust/detail/allocator/default_construct_range.inl
@@ -79,7 +79,7 @@ template<typename Allocator, typename Pointer, typename Size>
 
 template<typename Allocator, typename Pointer, typename Size>
   typename disable_if<
-    has_member_construct1<
+    needs_default_construct_via_allocator<
       Allocator,
       typename pointer_element<Pointer>::type
     >::value


### PR DESCRIPTION
Reported by Andrew Corrigan

Fixes #224
