### PR TITLE
Use explicitly signed and sized types for testing rather than relying on...

### DIFF
--- a/testing/functional.cu
+++ b/testing/functional.cu
@@ -56,14 +56,14 @@ void TestBinaryFunctional(void)
 // XXX add bool to list
 // Instantiate a macro for all integer-like data types
 #define INSTANTIATE_INTEGER_TYPES(Macro, vector_type, operator_name)   \
-Macro(vector_type, operator_name, char          )                      \
-Macro(vector_type, operator_name, unsigned char )                      \
-Macro(vector_type, operator_name, short         )                      \
-Macro(vector_type, operator_name, unsigned short)                      \
-Macro(vector_type, operator_name, int           )                      \
-Macro(vector_type, operator_name, unsigned int  )                      \
-Macro(vector_type, operator_name, long          )                      \
-Macro(vector_type, operator_name, unsigned long )
+Macro(vector_type, operator_name, unittest::int8_t  )                  \
+Macro(vector_type, operator_name, unittest::uint8_t )                  \
+Macro(vector_type, operator_name, unittest::int16_t )                  \
+Macro(vector_type, operator_name, unittest::uint16_t)                  \
+Macro(vector_type, operator_name, unittest::int32_t )                  \
+Macro(vector_type, operator_name, unittest::uint32_t)                  \
+Macro(vector_type, operator_name, unittest::int64_t )                  \
+Macro(vector_type, operator_name, unittest::uint64_t)
 
 // Instantiate a macro for all integer and floating point data types
 #define INSTANTIATE_ALL_TYPES(Macro, vector_type, operator_name)       \

--- a/testing/functional_arithmetic.cu
+++ b/testing/functional_arithmetic.cu
@@ -35,14 +35,14 @@ void TestBinaryFunctional(void)
 // XXX add bool to list
 // Instantiate a macro for all integer-like data types
 #define INSTANTIATE_INTEGER_TYPES(Macro, vector_type, operator_name)   \
-Macro(vector_type, operator_name, char          )                      \
-Macro(vector_type, operator_name, unsigned char )                      \
-Macro(vector_type, operator_name, short         )                      \
-Macro(vector_type, operator_name, unsigned short)                      \
-Macro(vector_type, operator_name, int           )                      \
-Macro(vector_type, operator_name, unsigned int  )                      \
-Macro(vector_type, operator_name, long          )                      \
-Macro(vector_type, operator_name, unsigned long )
+Macro(vector_type, operator_name, unittest::int8_t  )                  \
+Macro(vector_type, operator_name, unittest::uint8_t )                  \
+Macro(vector_type, operator_name, unittest::int16_t )                  \
+Macro(vector_type, operator_name, unittest::uint16_t)                  \
+Macro(vector_type, operator_name, unittest::int32_t )                  \
+Macro(vector_type, operator_name, unittest::uint32_t)                  \
+Macro(vector_type, operator_name, unittest::int64_t )                  \
+Macro(vector_type, operator_name, unittest::uint64_t)
 
 // Instantiate a macro for all integer and floating point data types
 #define INSTANTIATE_ALL_TYPES(Macro, vector_type, operator_name)       \

--- a/testing/functional_bitwise.cu
+++ b/testing/functional_bitwise.cu
@@ -69,14 +69,14 @@ void TestBinaryFunctional(void)
 // XXX add bool to list
 // Instantiate a macro for all integer-like data types
 #define INSTANTIATE_INTEGER_TYPES(Macro, vector_type, operator_name)   \
-Macro(vector_type, operator_name, char          )                      \
-Macro(vector_type, operator_name, unsigned char )                      \
-Macro(vector_type, operator_name, short         )                      \
-Macro(vector_type, operator_name, unsigned short)                      \
-Macro(vector_type, operator_name, int           )                      \
-Macro(vector_type, operator_name, unsigned int  )                      \
-Macro(vector_type, operator_name, long          )                      \
-Macro(vector_type, operator_name, unsigned long )
+Macro(vector_type, operator_name, unittest::int8_t  )                  \
+Macro(vector_type, operator_name, unittest::uint8_t )                  \
+Macro(vector_type, operator_name, unittest::int16_t )                  \
+Macro(vector_type, operator_name, unittest::uint16_t)                  \
+Macro(vector_type, operator_name, unittest::int32_t )                  \
+Macro(vector_type, operator_name, unittest::uint32_t)                  \
+Macro(vector_type, operator_name, unittest::int64_t )                  \
+Macro(vector_type, operator_name, unittest::uint64_t)
 
 // Instantiate a macro for all integer and floating point data types
 #define INSTANTIATE_ALL_TYPES(Macro, vector_type, operator_name)       \

--- a/testing/functional_logical.cu
+++ b/testing/functional_logical.cu
@@ -33,14 +33,14 @@ void TestBinaryFunctional(void)
 // XXX add bool to list
 // Instantiate a macro for all integer-like data types
 #define INSTANTIATE_INTEGER_TYPES(Macro, vector_type, operator_name)   \
-Macro(vector_type, operator_name, char          )                      \
-Macro(vector_type, operator_name, unsigned char )                      \
-Macro(vector_type, operator_name, short         )                      \
-Macro(vector_type, operator_name, unsigned short)                      \
-Macro(vector_type, operator_name, int           )                      \
-Macro(vector_type, operator_name, unsigned int  )                      \
-Macro(vector_type, operator_name, long          )                      \
-Macro(vector_type, operator_name, unsigned long )
+Macro(vector_type, operator_name, unittest::int8_t  )                  \
+Macro(vector_type, operator_name, unittest::uint8_t )                  \
+Macro(vector_type, operator_name, unittest::int16_t )                  \
+Macro(vector_type, operator_name, unittest::uint16_t)                  \
+Macro(vector_type, operator_name, unittest::int32_t )                  \
+Macro(vector_type, operator_name, unittest::uint32_t)                  \
+Macro(vector_type, operator_name, unittest::int64_t )                  \
+Macro(vector_type, operator_name, unittest::uint64_t)
 
 // Instantiate a macro for all integer and floating point data types
 #define INSTANTIATE_ALL_TYPES(Macro, vector_type, operator_name)       \

--- a/testing/merge.cu
+++ b/testing/merge.cu
@@ -102,7 +102,7 @@ template<typename T>
   size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
   size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
-  thrust::host_vector<T> random = unittest::random_integers<char>(n + *thrust::max_element(sizes, sizes + num_sizes));
+  thrust::host_vector<T> random = unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
 
   thrust::host_vector<T> h_a(random.begin(), random.begin() + n);
   thrust::host_vector<T> h_b(random.begin() + n, random.end());

--- a/testing/pair_scan.cu
+++ b/testing/pair_scan.cu
@@ -66,5 +66,5 @@ template <typename T>
     ASSERT_EQUAL_QUIET(h_output, d_output);
   }
 };
-VariableUnitTest<TestPairScan, unittest::type_list<char,short,int> > TestPairScanInstance;
+VariableUnitTest<TestPairScan, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestPairScanInstance;
 

--- a/testing/pair_scan_by_key.cu
+++ b/testing/pair_scan_by_key.cu
@@ -57,5 +57,5 @@ template <typename T>
     ASSERT_EQUAL_QUIET(h_pairs, d_pairs);
   }
 };
-VariableUnitTest<TestPairScanByKey, unittest::type_list<char,short,int> > TestPairScanByKeyInstance;
+VariableUnitTest<TestPairScanByKey, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestPairScanByKeyInstance;
 

--- a/testing/pair_sort.cu
+++ b/testing/pair_sort.cu
@@ -46,5 +46,5 @@ template <typename T>
     ASSERT_EQUAL(h_values, d_values);
   }
 };
-VariableUnitTest<TestPairStableSortByKey, unittest::type_list<char,short,int> > TestPairStableSortByKeyInstance;
+VariableUnitTest<TestPairStableSortByKey, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestPairStableSortByKeyInstance;
 

--- a/testing/pair_sort_by_key.cu
+++ b/testing/pair_sort_by_key.cu
@@ -37,5 +37,5 @@ template <typename T>
     ASSERT_EQUAL_QUIET(h_pairs, d_pairs);
   }
 };
-VariableUnitTest<TestPairStableSort, unittest::type_list<char,short,int> > TestPairStableSortInstance;
+VariableUnitTest<TestPairStableSort, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestPairStableSortInstance;
 

--- a/testing/pair_transform.cu
+++ b/testing/pair_transform.cu
@@ -57,5 +57,5 @@ template <typename T>
     ASSERT_EQUAL_QUIET(h_result, d_result);
   }
 }; // end TestPairZip
-VariableUnitTest<TestPairTransform, unittest::type_list<char,short,int> > TestPairTransformInstance;
+VariableUnitTest<TestPairTransform, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestPairTransformInstance;
 

--- a/testing/partition.cu
+++ b/testing/partition.cu
@@ -13,7 +13,7 @@ struct is_even
     bool operator()(T x) const { return ((int) x % 2) == 0; }
 };
 
-typedef unittest::type_list<char,short,int> PartitionTypes;
+typedef unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> PartitionTypes;
 
 template<typename Vector>
 void TestPartitionSimple(void)

--- a/testing/reverse.cu
+++ b/testing/reverse.cu
@@ -3,7 +3,7 @@
 #include <thrust/iterator/discard_iterator.h>
 
 
-typedef unittest::type_list<char,short,int> ReverseTypes;
+typedef unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> ReverseTypes;
 
 template<typename Vector>
 void TestReverseSimple(void)

--- a/testing/scan.cu
+++ b/testing/scan.cu
@@ -353,7 +353,7 @@ struct TestScanWithOperatorToDiscardIterator
     ASSERT_EQUAL_QUIET(reference, d_result);
   }
 };
-VariableUnitTest<TestScanWithOperatorToDiscardIterator, unittest::type_list<char,short,int> > TestScanWithOperatorToDiscardIteratorInstance;
+VariableUnitTest<TestScanWithOperatorToDiscardIterator, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestScanWithOperatorToDiscardIteratorInstance;
 
 
 template <typename T>
@@ -425,7 +425,7 @@ struct TestScanToDiscardIterator
     ASSERT_EQUAL_QUIET(reference, d_result);
   }
 };
-VariableUnitTest<TestScanToDiscardIterator, unittest::type_list<char,short,int> > TestScanToDiscardIteratorInstance;
+VariableUnitTest<TestScanToDiscardIterator, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestScanToDiscardIteratorInstance;
 
 
 void TestScanMixedTypes(void)

--- a/testing/set_difference.cu
+++ b/testing/set_difference.cu
@@ -95,7 +95,7 @@ void TestSetDifference(const size_t n)
   size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
   size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
-  thrust::host_vector<T> random = unittest::random_integers<char>(n + *thrust::max_element(sizes, sizes + num_sizes));
+  thrust::host_vector<T> random = unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
 
   thrust::host_vector<T> h_a(random.begin(), random.begin() + n);
   thrust::host_vector<T> h_b(random.begin() + n, random.end());

--- a/testing/set_intersection.cu
+++ b/testing/set_intersection.cu
@@ -96,7 +96,7 @@ void TestSetIntersection(const size_t n)
   size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
   size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
-  thrust::host_vector<T> random = unittest::random_integers<char>(n + *thrust::max_element(sizes, sizes + num_sizes));
+  thrust::host_vector<T> random = unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
 
   thrust::host_vector<T> h_a(random.begin(), random.begin() + n);
   thrust::host_vector<T> h_b(random.begin() + n, random.end());

--- a/testing/set_symmetric_difference.cu
+++ b/testing/set_symmetric_difference.cu
@@ -95,7 +95,7 @@ void TestSetSymmetricDifference(const size_t n)
   size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
   size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
-  thrust::host_vector<T> random = unittest::random_integers<char>(n + *thrust::max_element(sizes, sizes + num_sizes));
+  thrust::host_vector<T> random = unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
 
   thrust::host_vector<T> h_a(random.begin(), random.begin() + n);
   thrust::host_vector<T> h_b(random.begin() + n, random.end());

--- a/testing/set_union.cu
+++ b/testing/set_union.cu
@@ -122,7 +122,7 @@ void TestSetUnion(const size_t n)
   size_t sizes[]   = {0, 1, n / 2, n, n + 1, 2 * n};
   size_t num_sizes = sizeof(sizes) / sizeof(size_t);
 
-  thrust::host_vector<T> random = unittest::random_integers<char>(n + *thrust::max_element(sizes, sizes + num_sizes));
+  thrust::host_vector<T> random = unittest::random_integers<unittest::int8_t>(n + *thrust::max_element(sizes, sizes + num_sizes));
 
   thrust::host_vector<T> h_a(random.begin(), random.begin() + n);
   thrust::host_vector<T> h_b(random.begin() + n, random.end());

--- a/testing/sort_by_key_variable_bits.cu
+++ b/testing/sort_by_key_variable_bits.cu
@@ -8,12 +8,11 @@ using namespace unittest;
 typedef unittest::type_list<
 #if !(defined(__GNUC__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ <= 1))
 // XXX GCC 4.1 miscompiles the char sorts with -O2 for some reason
-                            unsigned char,
+                            unittest::uint8_t,
 #endif
-                            unsigned short,
-                            unsigned int,
-                            unsigned long,
-                            unsigned long long> UnsignedIntegerTypes;
+                            unittest::uint16_t,
+                            unittest::uint32_t,
+                            unittest::uint64_t> UnsignedIntegerTypes;
 
 
 template <typename T>

--- a/testing/sort_variable_bits.cu
+++ b/testing/sort_variable_bits.cu
@@ -8,12 +8,11 @@ using namespace unittest;
 typedef unittest::type_list<
 #if !(defined(__GNUC__) && (__GNUC__ <= 4) && (__GNUC_MINOR__ <= 1))
 // XXX GCC 4.1 miscompiles the char sorts with -O2 for some reason
-                            unsigned char,
+                            unittest::uint8_t,
 #endif
-                            unsigned short,
-                            unsigned int,
-                            unsigned long,
-                            unsigned long long> UnsignedIntegerTypes;
+                            unittest::uint16_t,
+                            unittest::uint32_t,
+                            unittest::uint64_t> UnsignedIntegerTypes;
 
 template <typename T>
 struct TestSortVariableBits

--- a/testing/stable_sort.cu
+++ b/testing/stable_sort.cu
@@ -120,7 +120,7 @@ struct TestStableSortSemantics
         ASSERT_EQUAL(h_data, d_data);
     }
 };
-VariableUnitTest<TestStableSortSemantics, unittest::type_list<char,short,int> > TestStableSortSemanticsInstance;
+VariableUnitTest<TestStableSortSemantics, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestStableSortSemanticsInstance;
 
 
 template <typename T>

--- a/testing/stable_sort_by_key.cu
+++ b/testing/stable_sort_by_key.cu
@@ -133,5 +133,5 @@ struct TestStableSortByKeySemantics
         ASSERT_EQUAL(h_values, d_values);
     }
 };
-VariableUnitTest<TestStableSortByKeySemantics, unittest::type_list<char,short,int> > TestStableSortByKeySemanticsInstance;
+VariableUnitTest<TestStableSortByKeySemantics, unittest::type_list<unittest::uint8_t,unittest::uint16_t,unittest::uint32_t> > TestStableSortByKeySemanticsInstance;
 

--- a/testing/tuple_sort.cu
+++ b/testing/tuple_sort.cu
@@ -72,5 +72,5 @@ struct TestTupleStableSort
      ASSERT_ALMOST_EQUAL(h_values, d_values);
   }
 };
-VariableUnitTest<TestTupleStableSort, unittest::type_list<char,short,int> > TestTupleStableSortInstance;
+VariableUnitTest<TestTupleStableSort, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestTupleStableSortInstance;
 

--- a/testing/unittest/special_types.h
+++ b/testing/unittest/special_types.h
@@ -165,3 +165,20 @@ class my_system : public thrust::device_system<my_system>
 
 struct my_tag : thrust::device_system<my_tag> {};
 
+namespace unittest
+{
+
+
+using thrust::detail::int8_t;
+using thrust::detail::int16_t;
+using thrust::detail::int32_t;
+using thrust::detail::int64_t;
+
+using thrust::detail::uint8_t;
+using thrust::detail::uint16_t;
+using thrust::detail::uint32_t;
+using thrust::detail::uint64_t;
+
+  
+}
+

--- a/testing/zip_iterator_sort.cu
+++ b/testing/zip_iterator_sort.cu
@@ -27,5 +27,5 @@ template <typename T>
     ASSERT_EQUAL_QUIET(h2, d2);
   }
 };
-VariableUnitTest<TestZipIteratorStableSort, unittest::type_list<char,short,int> > TestZipIteratorStableSortInstance;
+VariableUnitTest<TestZipIteratorStableSort, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestZipIteratorStableSortInstance;
 

--- a/testing/zip_iterator_sort_by_key.cu
+++ b/testing/zip_iterator_sort_by_key.cu
@@ -54,5 +54,5 @@ template <typename T>
     ASSERT_EQUAL_QUIET(h4, d4);
   }
 };
-VariableUnitTest<TestZipIteratorStableSortByKey, unittest::type_list<char,short,int> > TestZipIteratorStableSortByKeyInstance;
+VariableUnitTest<TestZipIteratorStableSortByKey, unittest::type_list<unittest::int8_t,unittest::int16_t,unittest::int32_t> > TestZipIteratorStableSortByKeyInstance;
 


### PR DESCRIPTION
... the non-portable meaning of types such as char.

Fixes #233
