### PR TITLE
Eliminate uses of is_convertible<Reference,ValueParam> from iterator_fac...

### DIFF
--- a/thrust/detail/device_reference.inl
+++ b/thrust/detail/device_reference.inl
@@ -42,21 +42,6 @@ template<typename T>
   return super_t::operator=(x);
 } // end operator=()
 
-namespace detail
-{
-
-// XXX iterator_facade tries to instantiate the Reference
-//     type when computing the answer to is_convertible<Reference,Value>
-//     we can't do that at that point because device_reference
-//     is not complete
-//     WAR the problem by specializing is_convertible
-template<typename T>
-  struct is_convertible<thrust::device_reference<T>, T>
-    : thrust::detail::true_type
-{};
-
-} // end detail
-
 template<typename T>
 __host__ __device__
 void swap(device_reference<T> &a, device_reference<T> &b)

--- a/thrust/detail/pointer.h
+++ b/thrust/detail/pointer.h
@@ -67,10 +67,11 @@ template<typename Element, typename Tag, typename Reference, typename Derived>
   struct pointer_base
 {
   // void pointers should have no element type
+  // note that we remove_cv from the Element type to get the value_type
   typedef typename thrust::detail::eval_if<
     thrust::detail::is_void<typename thrust::detail::remove_const<Element>::type>::value,
     thrust::detail::identity_<void>,
-    thrust::detail::identity_<Element>
+    thrust::detail::remove_cv<Element>
   >::type value_type;
 
   // if no Derived type is given, just use pointer

--- a/thrust/detail/reference_forward_declaration.h
+++ b/thrust/detail/reference_forward_declaration.h
@@ -24,21 +24,5 @@ namespace thrust
 
 template<typename Element, typename Pointer, typename Derived = use_default> class reference;
 
-namespace detail
-{
-
-// XXX iterator_facade tries to instantiate the Reference
-//     type when computing the answer to is_convertible<Reference,Value>
-//     we can't do that at that point because reference
-//     is not complete
-//     WAR the problem by specializing is_convertible
-template<typename, typename> struct is_convertible;
-
-template<typename Element, typename Pointer, typename Derived>
-  struct is_convertible<reference<Element,Pointer,Derived>, Element>
-    : thrust::detail::true_type
-{};
-
-} // end detail
 } // end thrust
 

--- a/thrust/iterator/detail/iterator_facade_category.h
+++ b/thrust/iterator/detail/iterator_facade_category.h
@@ -102,20 +102,14 @@ namespace detail
 template<typename System, typename Traversal, typename ValueParam, typename Reference>
   struct iterator_facade_default_category;
 
-//
-// Convert an iterator_facade's traversal category, Value parameter,
-// and ::reference type to an appropriate old-style category.
-//
-// If writability has been disabled per the above metafunction, the
-// result will not be convertible to output_iterator_tag.
-//
-// Otherwise, if Traversal == single_pass_traversal_tag, the following
-// conditions will result in a tag that is convertible both to
-// input_iterator_tag and output_iterator_tag:
-//
-//    1. Reference is a reference to non-const
-//    2. Reference is not a reference and is convertible to Value
-//
+
+// Thrust's implementation of iterator_facade_default_category is slightly
+// different from Boost's equivalent.
+// Thrust does not check is_convertible<Reference, ValueParam> because Reference
+// may not be a complete type at this point, and implementations of is_convertible
+// typically require that both types be complete.
+// Instead, it simply assumes that if is_convertible<Traversal, single_pass_traversal_tag>,
+// then the category is input_iterator_tag
 
 
 // this is the function for standard system iterators
@@ -132,11 +126,8 @@ template<typename Traversal, typename ValueParam, typename Reference>
           thrust::detail::identity_<std::forward_iterator_tag>
         >
       >,
-      thrust::detail::eval_if<
-        thrust::detail::and_<
-          thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>,
-          thrust::detail::is_convertible<Reference, ValueParam>
-        >::value,
+      thrust::detail::eval_if< // XXX note we differ from Boost here
+        thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>::value,
         thrust::detail::identity_<std::input_iterator_tag>,
         thrust::detail::identity_<Traversal>
       >
@@ -159,11 +150,8 @@ template<typename Traversal, typename ValueParam, typename Reference>
           thrust::detail::identity_<thrust::forward_host_iterator_tag>
         >
       >,
-      thrust::detail::eval_if<
-        thrust::detail::and_<
-          thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>,
-          thrust::detail::is_convertible<Reference, ValueParam>
-        >::value,
+      thrust::detail::eval_if< // XXX note we differ from Boost here
+        thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>::value,
         thrust::detail::identity_<thrust::input_host_iterator_tag>,
         thrust::detail::identity_<Traversal>
       >
@@ -187,10 +175,7 @@ template<typename Traversal, typename ValueParam, typename Reference>
         >
       >,
       thrust::detail::eval_if<
-        thrust::detail::and_<
-          thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>,
-          thrust::detail::is_convertible<Reference, ValueParam>
-        >::value,
+        thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>::value, // XXX note we differ from Boost here
         thrust::detail::identity_<thrust::input_device_iterator_tag>,
         thrust::detail::identity_<Traversal>
       >
@@ -218,10 +203,7 @@ template<typename Traversal, typename ValueParam, typename Reference>
       >,
 
       thrust::detail::eval_if<
-        thrust::detail::and_<
-          thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>,
-          thrust::detail::is_convertible<Reference, ValueParam>
-        >::value,
+        thrust::detail::is_convertible<Traversal, thrust::single_pass_traversal_tag>::value, // XXX note we differ from Boost here
         thrust::detail::identity_<thrust::input_universal_iterator_tag>,
         thrust::detail::identity_<Traversal>
       >

--- a/thrust/system/cpp/detail/memory.inl
+++ b/thrust/system/cpp/detail/memory.inl
@@ -81,20 +81,5 @@ void free(pointer<void> ptr)
 
 } // end cpp
 } // end system
-
-namespace detail
-{
-
-// XXX iterator_facade tries to instantiate the Reference
-//     type when computing the answer to is_convertible<Reference,Value>
-//     we can't do that at that point because reference
-//     is not complete
-//     WAR the problem by specializing is_convertible
-template<typename T>
-  struct is_convertible<thrust::cpp::reference<T>, T>
-    : thrust::detail::true_type
-{};
-
-} // end detail
 } // end thrust
 

--- a/thrust/system/cuda/detail/memory.inl
+++ b/thrust/system/cuda/detail/memory.inl
@@ -83,20 +83,5 @@ void free(pointer<void> ptr)
 
 } // end cuda
 } // end system
-
-namespace detail
-{
-
-// XXX iterator_facade tries to instantiate the Reference
-//     type when computing the answer to is_convertible<Reference,Value>
-//     we can't do that at that point because reference
-//     is not complete
-//     WAR the problem by specializing is_convertible
-template<typename T>
-  struct is_convertible<thrust::cuda::reference<T>, T>
-    : thrust::detail::true_type
-{};
-
-} // end detail
 } // end thrust
 

--- a/thrust/system/omp/detail/memory.inl
+++ b/thrust/system/omp/detail/memory.inl
@@ -99,20 +99,5 @@ inline void free(pointer<void> ptr)
 
 } // end omp
 } // end system
-
-namespace detail
-{
-
-// XXX iterator_facade tries to instantiate the Reference
-//     type when computing the answer to is_convertible<Reference,Value>
-//     we can't do that at that point because reference
-//     is not complete
-//     WAR the problem by specializing is_convertible
-template<typename T>
-  struct is_convertible<thrust::omp::reference<T>, T>
-    : thrust::detail::true_type
-{};
-
-} // end detail
 } // end thrust
 

--- a/thrust/system/tbb/detail/memory.inl
+++ b/thrust/system/tbb/detail/memory.inl
@@ -99,20 +99,5 @@ inline void free(pointer<void> ptr)
 
 } // end tbb
 } // end system
-
-namespace detail
-{
-
-// XXX iterator_facade tries to instantiate the Reference
-//     type when ctbbuting the answer to is_convertible<Reference,Value>
-//     we can't do that at that point because reference
-//     is not ctbblete
-//     WAR the problem by specializing is_convertible
-template<typename T>
-  struct is_convertible<thrust::tbb::reference<T>, T>
-    : thrust::detail::true_type
-{};
-
-} // end detail
 } // end thrust
 


### PR DESCRIPTION
...ade_category which require Reference to be a complete type.

Eliminate specializations of is_convertible for Thrust's wrapped reference types.
Correctly use remove_cv from thrust::pointer's Element parameter to derive its value_type.

Fixes #227
Fixes #228
