### PR TITLE
Eliminate many warnings of the form 'calling a __host__ function from a

### DIFF
--- a/thrust/detail/config/config.h
+++ b/thrust/detail/config/config.h
@@ -32,4 +32,5 @@
 #include <thrust/detail/config/debug.h>
 #include <thrust/detail/config/compiler_fence.h>
 #include <thrust/detail/config/forceinline.h>
+#include <thrust/detail/config/hd_warning_disable.h>
 

--- a/thrust/detail/config/hd_warning_disable.h
+++ b/thrust/detail/config/hd_warning_disable.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2008-2012 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*! \file hd_warning_disable.h
+ *  \brief Defines __thrust_hd_warning_disable__
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(__CUDACC__)
+
+#define __thrust_hd_warning_disable__ \
+#pragma hd_warning_disable
+#else
+
+#define __thrust_hd_warning_disable__
+
+#endif
+
+

--- a/thrust/detail/function.h
+++ b/thrust/detail/function.h
@@ -169,6 +169,7 @@ template<typename Function, typename Result>
     : m_f(f)
   {}
 
+  __thrust_hd_warning_disable__
   template<typename Argument>
   inline __host__ __device__
     Result operator()(Argument &x) const

--- a/thrust/iterator/detail/zip_iterator.inl
+++ b/thrust/iterator/detail/zip_iterator.inl
@@ -70,6 +70,7 @@ template <typename IteratorTuple>
 } // end zip_iterator::dereference()
 
 
+__thrust_hd_warning_disable__
 template <typename IteratorTuple>
   template <typename OtherIteratorTuple>
     bool zip_iterator<IteratorTuple>
@@ -128,6 +129,7 @@ template <typename IteratorTuple>
 } // end zip_iterator::decrement()
 
 
+__thrust_hd_warning_disable__
 template <typename IteratorTuple>
   template <typename OtherIteratorTuple>
     typename zip_iterator<IteratorTuple>::super_t::difference_type

--- a/thrust/iterator/detail/zip_iterator_base.h
+++ b/thrust/iterator/detail/zip_iterator_base.h
@@ -84,6 +84,8 @@ struct dereference_iterator
     type;
   }; // end apply
 
+  // XXX silence warnings of the form "calling a __host__ function from a __host__ __device__ function is not allowed
+  __thrust_hd_warning_disable__
   template<typename Iterator>
   __host__ __device__
     typename apply<Iterator>::type operator()(Iterator const& it)

--- a/thrust/iterator/iterator_adaptor.h
+++ b/thrust/iterator/iterator_adaptor.h
@@ -94,15 +94,18 @@ template <
 
   private: // Core iterator interface for iterator_facade
 
+    __thrust_hd_warning_disable__
     __host__ __device__
     typename iterator_adaptor::reference dereference() const
     { return *m_iterator; }
 
+    __thrust_hd_warning_disable__
     template<typename OtherDerived, typename OtherIterator, typename V, typename S, typename T, typename R, typename D>
     __host__ __device__
     bool equal(iterator_adaptor<OtherDerived, OtherIterator, V, S, T, R, D> const& x) const
     { return m_iterator == x.base(); }
 
+    __thrust_hd_warning_disable__
     __host__ __device__
     void advance(typename iterator_adaptor::difference_type n)
     {
@@ -110,10 +113,12 @@ template <
       m_iterator += n;
     }
 
+    __thrust_hd_warning_disable__
     __host__ __device__
     void increment()
     { ++m_iterator; }
 
+    __thrust_hd_warning_disable__
     __host__ __device__
     void decrement()
     {
@@ -121,6 +126,7 @@ template <
       --m_iterator;
     }
 
+    __thrust_hd_warning_disable__
     template<typename OtherDerived, typename OtherIterator, typename V, typename S, typename T, typename R, typename D>
     __host__ __device__
     typename iterator_adaptor::difference_type distance_to(iterator_adaptor<OtherDerived, OtherIterator, V, S, T, R, D> const& y) const

--- a/thrust/iterator/permutation_iterator.h
+++ b/thrust/iterator/permutation_iterator.h
@@ -167,6 +167,7 @@ template <typename ElementIterator,
   /*! \cond
    */
   private:
+    __thrust_hd_warning_disable__
     __host__ __device__
     typename super_t::reference dereference() const
     {

--- a/thrust/iterator/transform_iterator.h
+++ b/thrust/iterator/transform_iterator.h
@@ -296,6 +296,7 @@ template <class AdaptableUnaryFunction, class Iterator, class Reference = use_de
       return *this;
     }
 
+    __thrust_hd_warning_disable__
     __host__ __device__
     typename super_t::reference dereference() const
     { 


### PR DESCRIPTION
**host** **device** function is not allowed' in transform_iterator, zip_iterator, and permutation_iterator.
