### PR TITLE
Don't redefine THRUST_GCC_VERSION in config/compiler_fence.h

### DIFF
--- a/testing/memory.cu
+++ b/testing/memory.cu
@@ -195,6 +195,10 @@ void TestGetTemporaryBufferDispatchImplicit()
   }
   else
   {
+#if defined(THRUST_GCC_VERSION) && (THRUST_GCC_VERSION < 40300)
+    // gcc 4.2 does not do adl correctly for get_temporary_buffer
+    KNOWN_FAILURE;
+#else
     thrust::device_vector<int> vec(9001);
 
     thrust::sequence(vec.begin(), vec.end());
@@ -206,6 +210,7 @@ void TestGetTemporaryBufferDispatchImplicit()
 
     ASSERT_EQUAL(true, thrust::is_sorted(vec.begin(), vec.end()));
     ASSERT_EQUAL(true, sys.is_valid());
+#endif
   }
 }
 DECLARE_UNITTEST(TestGetTemporaryBufferDispatchImplicit);

--- a/thrust/detail/config/compiler_fence.h
+++ b/thrust/detail/config/compiler_fence.h
@@ -35,18 +35,12 @@
 // gcc case
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 
-// guard use of __sync_synchronize from older compilers
-#define THRUST_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-
 #if THRUST_GCC_VERSION >= 40200 // atomic built-ins were introduced ~4.2
 #define __thrust_compiler_fence() __sync_synchronize()
 #else
 // allow the code to compile without any guarantees
 #define __thrust_compiler_fence() do {} while (0)
 #endif // THRUST_GCC_VERSION
-
-// clean up after ourselves
-#undef THRUST_GCC_VERSION
 
 // unknown case
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_UNKNOWN


### PR DESCRIPTION
Mark TestGetTemporaryBufferDispatchImplicit as a KNOWN_FAILURE on gcc <= 4.2

Fixes #284
