### PR TITLE
Avoid binding references to temporaries in uninitialized_copy and uninit...

### DIFF
--- a/thrust/detail/allocator/copy_construct_range.inl
+++ b/thrust/detail/allocator/copy_construct_range.inl
@@ -49,8 +49,9 @@ template<typename Allocator, typename InputType, typename OutputType>
     : a(a)
   {}
 
+  template<typename Tuple>
   inline __host__ __device__
-  void operator()(thrust::tuple<const InputType&,OutputType&> t)
+  void operator()(Tuple t)
   {
     const InputType &in = thrust::get<0>(t);
     OutputType &out = thrust::get<1>(t);

--- a/thrust/system/detail/generic/uninitialized_copy.inl
+++ b/thrust/system/detail/generic/uninitialized_copy.inl
@@ -37,8 +37,9 @@ template<typename InputType,
          typename OutputType>
   struct uninitialized_copy_functor
 {
+  template<typename Tuple>
   __host__ __device__
-  void operator()(thrust::tuple<const InputType&,OutputType&> t)
+  void operator()(Tuple t)
   {
     const InputType &in = thrust::get<0>(t);
     OutputType &out = thrust::get<1>(t);


### PR DESCRIPTION
...ialized_copy_with_allocator's functors.

Reported by Andrew Corrigan
