### PR TITLE
Add device_vector::operator=(const host_vector &) (and vice versa) to

### DIFF
--- a/thrust/device_vector.h
+++ b/thrust/device_vector.h
@@ -130,6 +130,14 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
     __host__
     device_vector(const host_vector<OtherT,OtherAlloc> &v);
 
+    /*! Assign operator copies from an examplar \p host_vector.
+     *  \param v The \p host_vector to copy.
+     */
+    template<typename OtherT, typename OtherAlloc>
+    __host__
+    device_vector &operator=(const host_vector<OtherT,OtherAlloc> &v)
+    { Parent::operator=(v); return *this; }
+
     /*! This constructor builds a \p device_vector from a range.
      *  \param first The beginning of the range.
      *  \param last The end of the range.

--- a/thrust/host_vector.h
+++ b/thrust/host_vector.h
@@ -137,6 +137,14 @@ template<typename T, typename Alloc = std::allocator<T> >
     __host__
     host_vector(const device_vector<OtherT,OtherAlloc> &v);
 
+    /*! Assign operator copies from an exemplar \p device_vector.
+     *  \param v The \p device_vector to copy.
+     */
+    template<typename OtherT, typename OtherAlloc>
+    __host__
+    host_vector &operator=(const device_vector<OtherT,OtherAlloc> &v)
+    { Parent::operator=(v); return *this; }
+
     /*! This constructor builds a \p host_vector from a range.
      *  \param first The beginning of the range.
      *  \param last The end of the range.


### PR DESCRIPTION
eliminate unintentional temporary copies during assignment.

Reported by Shiyin Kang

Fixes #325
