### PR TITLE
make CUDA the default backend only if using nvcc

### DIFF
--- a/thrust/detail/config/device_system.h
+++ b/thrust/detail/config/device_system.h
@@ -22,8 +22,18 @@
 #define THRUST_DEVICE_SYSTEM_TBB     3
 #define THRUST_DEVICE_SYSTEM_CPP     4
 
+// make CUDA the default only if using nvcc (otherwise OpenMP or CPP)
+// this makes Thrust usable out-of-the-box on systems without CUDA
+// even if no THRUST_DEVICE_SYSTEM was specified
+// (up to Thrust 1.7 CUDA was the default)
 #ifndef THRUST_DEVICE_SYSTEM
-#define THRUST_DEVICE_SYSTEM THRUST_DEVICE_SYSTEM_CUDA
+#  if defined(__NVCC__)
+#    define THRUST_DEVICE_SYSTEM THRUST_DEVICE_SYSTEM_CUDA
+#  elif defined(_OPENMP)
+#    define THRUST_DEVICE_SYSTEM THRUST_DEVICE_SYSTEM_OMP
+#  else
+#    define THRUST_DEVICE_SYSTEM THRUST_DEVICE_SYSTEM_CPP
+#  endif
 #endif // THRUST_DEVICE_SYSTEM
 
 // XXX make the use of THRUST_DEVICE_BACKEND an error in Thrust 1.7


### PR DESCRIPTION
This fixes the issue described here:
http://code.google.com/p/thrust/issues/detail?id=312

The two suggested solutions are:
1) compile the .cpp files with nvcc
2) supply the path to the CUDA headers to the host compiler (e.g. g++ -I /usr/local/cuda/include)

Both require CUDA to be installed on the system.

Defining THRUST_DEVICE_BACKEND fixes the problem for users with no CUDA files on the system, but it conflicts with using multiple backends in one translation unit as mentioned here:
https://groups.google.com/forum/#!msg/thrust-users/r_aorLOXnpI/wLjQmFKMOFcJ

HTH,
Sylwester
