### PR TITLE
Corrected bug in normal_distribution_portable

### DIFF
--- a/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/random/detail/normal_distribution_base.h
@@ -125,7 +125,7 @@ template<typename RealType>
                           cos(RealType(2)*pi*m_r1) :
                           sin(RealType(2)*pi*m_r1));
 
-      return result;
+      return mean + stddev * result;
     }
 
   private:


### PR DESCRIPTION
Returned standard normal, ignoring specified mean and stddev
