### PR TITLE
Compile in 64bit, and remove 64 suffix from library on OSX. Fixes #356

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -231,14 +231,6 @@ def linker_flags(LINK, mode, platform, device_backend):
   # unconditional workarounds
   result.extend(flags['workarounds'])
 
-  # conditional workarounds
-
-#   Since CUDA 3.1 this workaround is no longer necessary
-#
-#   on darwin, we need to tell the linker to build 32b code for cuda
-#  if platform == 'darwin' and device_backend == 'cuda':
-#    result.append('-m32')
-
   return result
 
   
@@ -290,12 +282,6 @@ def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_al
 
   # workarounds
   result.extend(flags['workarounds'])
-
-  # Since CUDA 3.1 this is no longer necessary
-  #
-  # on darwin, we need to tell the compiler to build 32b code for cuda
-  #  if platform == 'darwin' and device_backend == 'cuda':
-  #    result.append('-m32')
 
   return result
 


### PR DESCRIPTION
Since CUDA 3.1 there is support for 64bit on OSX, so I think it's time to remove the -m32 from the build script.
I've also set the correct -L path on OSX for a default CUDA install (/usr/local/cuda/lib not /usr/local/cuda/lib64).
