### PR TITLE
added template default arguments for iterator_facade - Reference and Dif...

### DIFF
--- a/thrust/iterator/iterator_facade.h
+++ b/thrust/iterator/iterator_facade.h
@@ -247,7 +247,7 @@ template<typename Derived,
          typename Value,
          typename System,
          typename Traversal,
-         typename Reference = Value&,
+         typename Reference,
          typename Difference = std::ptrdiff_t>
   class iterator_facade
 {


### PR DESCRIPTION
I am not sure if these defaults were intentionally left out or just forgotten? In case there is a reason, I would add them to the point in the documentation which explains the differences from boost. 

Tests still compile and run for me.
