### PR TITLE
Add range-based for_each and transform

### DIFF
--- a/thrust/detail/for_each.inl
+++ b/thrust/detail/for_each.inl
@@ -58,6 +58,39 @@ InputIterator for_each(InputIterator first,
   return thrust::for_each(select_system(system), first, last, f);
 } // end for_each()
 
+
+template<typename SinglePassRange,
+         typename UnaryFunction>
+SinglePassRange for_each(SinglePassRange& range,
+                       UnaryFunction f)
+{
+  using thrust::system::detail::generic::select_system;
+  typedef typename SinglePassRange::iterator Iterator;
+  typedef typename thrust::iterator_system<Iterator>::type System;
+
+  System system;
+  thrust::for_each(select_system(system), std::begin(range),
+                   std::end(range), f);
+  return range;
+} // end for_each()
+
+
+template<typename SinglePassRange,
+         typename UnaryFunction>
+SinglePassRange for_each(SinglePassRange const& range,
+                       UnaryFunction f)
+{
+  using thrust::system::detail::generic::select_system;
+  typedef typename SinglePassRange::iterator Iterator;
+  typedef typename thrust::iterator_system<Iterator>::type System;
+
+  System system;
+  thrust::for_each(select_system(system), std::begin(range),
+                   std::end(range), f);
+  return range;
+} // end for_each()
+
+
 __thrust_hd_warning_disable__ 
 template<typename DerivedPolicy, typename InputIterator, typename Size, typename UnaryFunction>
 __host__ __device__

--- a/thrust/detail/transform.inl
+++ b/thrust/detail/transform.inl
@@ -143,6 +143,44 @@ template<typename InputIterator,
 } // end transform()
 
 
+template<typename SinglePassRange,
+         typename OutputIterator,
+         typename UnaryFunction>
+OutputIterator transform(SinglePassRange& range, OutputIterator result,
+                         UnaryFunction op)
+{
+  using thrust::system::detail::generic::select_system;
+  typedef typename SinglePassRange::iterator Iterator;
+  typedef typename thrust::iterator_system<Iterator>::type  System1;
+  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+
+  System1 system1;
+  System2 system2;
+
+  return thrust::transform(select_system(system1,system2), std::begin(range),
+                           std::end(range), result, op);
+} // end transform()
+
+
+template<typename SinglePassRange,
+         typename OutputIterator,
+         typename UnaryFunction>
+OutputIterator transform(SinglePassRange const& range, OutputIterator result,
+                         UnaryFunction op)
+{
+  using thrust::system::detail::generic::select_system;
+  typedef typename SinglePassRange::iterator Iterator;
+  typedef typename thrust::iterator_system<Iterator>::type  System1;
+  typedef typename thrust::iterator_system<OutputIterator>::type System2;
+
+  System1 system1;
+  System2 system2;
+
+  return thrust::transform(select_system(system1,system2), std::begin(range),
+                           std::end(range), result, op);
+} // end transform()
+
+
 template<typename InputIterator1,
          typename InputIterator2,
          typename OutputIterator,

--- a/thrust/detail/transform_reduce.inl
+++ b/thrust/detail/transform_reduce.inl
@@ -68,5 +68,46 @@ template<typename InputIterator,
 } // end transform_reduce()
 
 
+template<typename SinglePassRange,
+         typename UnaryFunction,
+         typename OutputType,
+         typename BinaryFunction>
+OutputType transform_reduce(SinglePassRange & range,
+                            UnaryFunction unary_op,
+                            OutputType init,
+                            BinaryFunction binary_op)
+{
+  using thrust::system::detail::generic::select_system;
+
+  typedef typename SinglePassRange::iterator Iterator;
+  typedef typename thrust::iterator_system<Iterator>::type System;
+
+  System system;
+
+  return thrust::transform_reduce(select_system(system), std::begin(range),
+                                  std::end(range), unary_op, init, binary_op);
+} // end transform_reduce()
+
+template<typename SinglePassRange,
+         typename UnaryFunction,
+         typename OutputType,
+         typename BinaryFunction>
+OutputType transform_reduce(SinglePassRange const& range,
+                            UnaryFunction unary_op,
+                            OutputType init,
+                            BinaryFunction binary_op)
+{
+  using thrust::system::detail::generic::select_system;
+
+  typedef typename SinglePassRange::iterator Iterator;
+  typedef typename thrust::iterator_system<Iterator>::type System;
+
+  System system;
+
+  return thrust::transform_reduce(select_system(system), std::begin(range),
+                                  std::end(range), unary_op, init, binary_op);
+} // end transform_reduce()
+
+
 } // end namespace thrust
 

--- a/thrust/for_each.h
+++ b/thrust/for_each.h
@@ -216,6 +216,65 @@ InputIterator for_each(InputIterator first,
                        UnaryFunction f);
 
 
+/*! \p for_each applies the function object \p f to each element
+ *  in the range <tt>[first, last)</tt>; \p f's return value, if any,
+ *  is ignored. Unlike the C++ Standard Template Library function
+ *  <tt>std::for_each</tt>, this version offers no guarantee on
+ *  order of execution. For this reason, this version of \p for_each
+ *  does not return a copy of the function object.
+ *
+ *  \param range The input sequence [first, last).
+ *  \param last The end of the sequence.
+ *  \param f The function object to apply to the range <tt>[first, last)</tt>.
+ *  \return last
+ *
+ *  \tparam SinglePassRange is a model of <a
+ * href="http://www.boost.org/doc/libs/1_55_0/libs/range/doc/html/range/concepts/single_pass_range.html">SinglePassRange</a>
+ * concept, and \p SinglePassRange's \c value_type is convertible to \p
+ * UnaryFunction's \c argument_type.
+ *  \tparam UnaryFunction is a model of <a
+ * href="http://www.sgi.com/tech/stl/UnaryFunction">Unary Function</a> concept,
+ * and \p UnaryFunction does not apply any non-constant operation through its
+ * argument.
+ *
+ *  The following code snippet demonstrates how to use \p for_each to print the
+ *  elements of a \p device_vector.
+ *
+ *  \code
+ *  #include <thrust/for_each.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <stdio.h>
+ *
+ *  struct printf_functor
+ *  {
+ *    __host__ __device__
+ *    void operator()(int x)
+ *    {
+ *      // note that using printf in a __device__ function requires
+ *      // code compiled for a GPU with compute capability 2.0 or
+ *      // higher (nvcc --arch=sm_20)
+ *      printf("%d\n");
+ *    }
+ *  };
+ *  ...
+ *  thrust::device_vector<int> d_vec(3);
+ *  d_vec[0] = 0; d_vec[1] = 1; d_vec[2] = 2;
+ *
+ *  thrust::for_each(d_vec, printf_functor());
+ *
+ *  // 0 1 2 is printed to standard output in some unspecified order
+ *  \endcode
+ *
+ *  \see for_each_n
+ *  \see http://www.sgi.com/tech/stl/for_each.html
+ */
+template <typename SinglePassRange, typename UnaryFunction>
+SinglePassRange for_each(SinglePassRange& range, UnaryFunction f);
+
+template <typename SinglePassRange, typename UnaryFunction>
+SinglePassRange for_each(SinglePassRange const& range, UnaryFunction f);
+
+
 /*! \p for_each_n applies the function object \p f to each element
  *  in the range <tt>[first, first + n)</tt>; \p f's return value, if any,
  *  is ignored. Unlike the C++ Standard Template Library function

--- a/thrust/transform.h
+++ b/thrust/transform.h
@@ -143,6 +143,65 @@ template<typename InputIterator,
                            UnaryFunction op);
 
 
+/*! This version of \p transform applies a unary function to each element
+ *  of an input sequence and stores the result in the corresponding 
+ *  position in an output sequence.  Specifically, for each iterator 
+ *  <tt>i</tt> in the range [\p first, \p last) the operation 
+ *  <tt>op(*i)</tt> is performed and the result is assigned to <tt>*o</tt>,
+ *  where <tt>o</tt> is the corresponding output iterator in the range
+ *  [\p result, \p result + (\p last - \p first) ).  The input and
+ *  output sequences may coincide, resulting in an in-place transformation.
+ *    
+ *  \param range The input sequence [first, last).
+ *  \param result The beginning of the output sequence.
+ *  \param op The tranformation operation.
+ *  \return The end of the output sequence.
+ *
+ *  \tparam SinglePassRange is a model of <a
+ *  href="http://www.boost.org/doc/libs/1_55_0/libs/range/doc/html/range/concepts/single_pass_range.html">SinglePassRange</a>
+ *  concept, and \p SinglePassRange's \c value_type is convertible to \p
+ *  UnaryFunction's \c argument_type.
+ *  \tparam OutputIterator is a model of <a
+ *  href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>.
+ *  \tparam UnaryFunction is a model of <a
+ *  href="http://www.sgi.com/tech/stl/UnaryFunction.html">Unary Function</a> and
+ *  \c UnaryFunction's \c result_type is convertible to \c OutputIterator's \c
+ *  value_type.
+ *
+ *  \pre \p first may equal \p result, but the range <tt>[first, last)</tt>
+ *  shall not overlap the range <tt>[result, result + (last - first))</tt>
+ *  otherwise.
+ *
+ *  The following code snippet demonstrates how to use \p transform
+ *
+ *  \code
+ *  #include <thrust/host_vector.h>
+ *  #include <thrust/transform.h>
+ *  #include <thrust/functional.h>
+ *  
+ *  thrust::host_vector<int> data = {-5, 0, 2, -3, 2, 4, 0, -1, 2, 8};
+ * 
+ *  thrust::negate<int> op;
+ *
+ *  thrust::transform(data, std::begin(data), op); // in-place transformation
+ *
+ *  // data is now {5, 0, -2, 3, -2, -4, 0, 1, -2, -8};
+ *  \endcode
+ *
+ *  \see http://www.sgi.com/tech/stl/transform.html
+ */
+template<typename SinglePassRange,
+         typename OutputIterator,
+         typename UnaryFunction>
+OutputIterator transform(SinglePassRange& range, OutputIterator result,
+                         UnaryFunction op);
+template<typename SinglePassRange,
+         typename OutputIterator,
+         typename UnaryFunction>
+OutputIterator transform(SinglePassRange const& range, OutputIterator result,
+                         UnaryFunction op);
+
+
 /*! This version of \p transform applies a binary function to each pair
  *  of elements from two input sequences and stores the result in the
  *  corresponding position in an output sequence.  Specifically, for

--- a/thrust/transform_reduce.h
+++ b/thrust/transform_reduce.h
@@ -187,6 +187,88 @@ template<typename InputIterator,
                               BinaryFunction binary_op);
 
 
+/*! \p transform_reduce fuses the \p transform and \p reduce operations.
+ *  \p transform_reduce is equivalent to performing a transformation defined by
+ *  \p unary_op into a temporary sequence and then performing \p reduce on the
+ *  transformed sequence. In most cases, fusing these two operations together is
+ *  more efficient, since fewer memory reads and writes are required.
+ *
+ *  \p transform_reduce performs a reduction on the transformation of the
+ *  sequence <tt>[first, last)</tt> according to \p unary_op. Specifically,
+ *  \p unary_op is applied to each element of the sequence and then the result
+ *  is reduced to a single value with \p binary_op using the initial value
+ *  \p init.  Note that the transformation \p unary_op is not applied to
+ *  the initial value \p init.  The order of reduction is not specified,
+ *  so \p binary_op must be both commutative and associative.
+ *
+ *  \param range The input sequence [first, last).
+ *  \param unary_op The function to apply to each element of the input sequence.
+ *  \param init The result is initialized to this value.
+ *  \param binary_op The reduction operation.
+ *  \return The result of the transformed reduction.
+ *
+ *  \tparam SinglePassRange is a model of <a
+ *  href="http://www.boost.org/doc/libs/1_55_0/libs/range/doc/html/range/concepts/single_pass_range.html">SinglePassRange</a>
+ *  concept, and \p SinglePassRange's \c value_type is convertible to \p
+ *  UnaryFunction's \c argument_type.
+ *  \tparam UnaryFunction is a model of <a
+ *          href="http://www.sgi.com/tech/stl/UnaryFunction.html">Unary
+ *          Function</a>, and \p UnaryFunction's \c result_type is convertible
+ *          to \c OutputType.
+ *  \tparam OutputType is a model of <a
+ *          href="http://www.sgi.com/tech/stl/Assignable.html">Assignable</a>,
+ *          and is convertible to \p BinaryFunction's \c first_argument_type and
+ *          \c second_argument_type.
+ *  \tparam BinaryFunction is a model of <a
+ *          href="http://www.sgi.com/tech/stl/BinaryFunction.html">Binary
+ *          Function</a>, and \p BinaryFunction's \c result_type is convertible
+ *          to \p OutputType.
+ *
+ *  The following code snippet demonstrates how to use \p transform_reduce
+ *  to compute the maximum value of the absolute value of the elements
+ *  of a range.
+ *
+ *  \code
+ *  #include <thrust/host_vector.h>
+ *  #include <thrust/transform_reduce.h>
+ *  #include <thrust/functional.h>
+ *
+ *  template<typename T>
+ *  struct absolute_value : public unary_function<T,T>
+ *  {
+ *    __host__ __device__ T operator()(const T &x) const
+ *    {
+ *      return x < T(0) ? -x : x;
+ *    }
+ *  };
+ *
+ *  ...
+ *
+ *  thrust::host_vector<int> data = {-1, 0, -2, -2, 1, -3};
+ *  int result = thrust::transform_reduce(data,
+ *                                        absolute_value<int>(),
+ *                                        0,
+ *                                        thrust::maximum<int>());
+ *  // result == 3
+ *  \endcode
+ *
+ *  \see \c transform
+ *  \see \c reduce
+ */
+template<typename SinglePassRange,
+         typename UnaryFunction,
+         typename OutputType,
+         typename BinaryFunction>
+OutputType transform_reduce(SinglePassRange& range, UnaryFunction unary_op,
+                            OutputType init, BinaryFunction binary_op);
+
+template<typename SinglePassRange,
+         typename UnaryFunction,
+         typename OutputType,
+         typename BinaryFunction>
+OutputType transform_reduce(SinglePassRange const& range, UnaryFunction unary_op,
+                            OutputType init, BinaryFunction binary_op);
+
 /*! \} // end transformed_reductions
  *  \} // end reductions
  */


### PR DESCRIPTION
Range-based interface for:
- thrust::for_each,
- thrust::transform, and
- thrust::transform_reduce.

Initial proposal of range-based interfaces
which mimicks Boost.Range 2.0, see issue #127.

Each range algorithm takes a range by either lvalue
reference or const lvalue reference. This allows to
 iterate over lvalues, const lvalues, and rvalues.

This introduces some code duplication. Support for
rvalue references (issue #129) would fix this since the reference
colapsing rules for SinglePassRange&& would deduce the
correct reference type. Rvalue reference would also allow
further optimizations (e.g. perfect forwarding).
