### PR TITLE
Replace remaining non-test use of std::min

### DIFF
--- a/thrust/system/cuda/detail/detail/stable_merge_sort.inl
+++ b/thrust/system/cuda/detail/detail/stable_merge_sort.inl
@@ -43,7 +43,6 @@
 #include <thrust/system/cuda/detail/block/copy.h>
 #include <thrust/pair.h>
 #include <thrust/tuple.h>
-#include <thrust/extrema.h>
 #include <thrust/detail/minmax.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>


### PR DESCRIPTION
Replace remaining non-test use of std::min with thrust::min in max_grid_size
