### PR TITLE
Add a seed parameter and default value to random_vector function

### DIFF
--- a/examples/dot_products_with_zip.cu
+++ b/examples/dot_products_with_zip.cu
@@ -33,9 +33,10 @@ struct DotProduct : public thrust::binary_function<Float3,Float3,float>
 
 
 // Return a host vector with random values in the range [0,1)
-thrust::host_vector<float> random_vector(const size_t N)
+thrust::host_vector<float> random_vector(const size_t N,
+                                         unsigned int seed = thrust::default_random_engine::default_seed)
 {
-    thrust::default_random_engine rng;
+    thrust::default_random_engine rng(seed);
     thrust::uniform_real_distribution<float> u01(0.0f, 1.0f);
     thrust::host_vector<float> temp(N);
     for(size_t i = 0; i < N; i++) {


### PR DESCRIPTION
All the invocations of random_vector still use the same seed, in
order to preserve the output of the program. This is important to
not interfere with testing. People that wish to experiment with
the example program or use the random_vector() function in their
own codes can supply their own seeds.

Fixes #390
