### PR TITLE
Removed dependency on STL iterator_traits

### DIFF
--- a/thrust/detail/pointer.h
+++ b/thrust/detail/pointer.h
@@ -32,11 +32,11 @@ template<typename Element, typename Tag, typename Reference = use_default, typen
 } // end thrust
 
 
-// specialize std::iterator_traits to avoid problems with the name of
+// specialize thrust::iterator_traits to avoid problems with the name of
 // pointer's constructor shadowing its nested pointer type
 // do this before pointer is defined so the specialization is correctly
 // used inside the definition
-namespace std
+namespace thrust
 {
 
 template<typename Element, typename Tag, typename Reference, typename Derived>
@@ -54,7 +54,7 @@ template<typename Element, typename Tag, typename Reference, typename Derived>
     typedef typename ptr::reference         reference;
 }; // end iterator_traits
 
-} // end std
+} // end thrust
 
 
 namespace thrust

--- a/thrust/iterator/iterator_traits.h
+++ b/thrust/iterator/iterator_traits.h
@@ -41,10 +41,34 @@ namespace thrust
  */
 template<typename T>
   struct iterator_traits
-    : public std::iterator_traits<T>
 {
-}; // end iterator_traits
+  typedef typename T::difference_type difference_type;
+  typedef typename T::value_type value_type;
+  typedef typename T::pointer pointer;
+  typedef typename T::reference reference;
+  typedef typename T::iterator_category iterator_category;
+};
 
+// traits are specialized for pointer types
+template<typename T>
+  struct iterator_traits<T*>
+{
+  typedef std::ptrdiff_t difference_type;
+  typedef T value_type;
+  typedef T* pointer;
+  typedef T& reference;
+  typedef std::random_access_iterator_tag iterator_category;
+};
+
+template<typename T>
+  struct iterator_traits<const T*>
+{
+  typedef std::ptrdiff_t difference_type;
+  typedef T value_type;
+  typedef const T* pointer;
+  typedef const T& reference;
+  typedef std::random_access_iterator_tag iterator_category;
+}; // end iterator_traits
 
 template<typename Iterator> struct iterator_value;
 

--- a/thrust/system/cpp/memory.h
+++ b/thrust/system/cpp/memory.h
@@ -44,11 +44,11 @@ template<typename> class pointer;
 /*! \cond
  */
 
-// specialize std::iterator_traits to avoid problems with the name of
+// specialize thrust::iterator_traits to avoid problems with the name of
 // pointer's constructor shadowing its nested pointer type
 // do this before pointer is defined so the specialization is correctly
 // used inside the definition
-namespace std
+namespace thrust
 {
 
 template<typename Element>
@@ -65,7 +65,7 @@ template<typename Element>
     typedef typename ptr::reference               reference;
 }; // end iterator_traits
 
-} // end std
+} // end thrust
 
 /*! \endcond
  */

--- a/thrust/system/cuda/memory.h
+++ b/thrust/system/cuda/memory.h
@@ -44,11 +44,11 @@ template<typename> class pointer;
 /*! \cond
  */
 
-// specialize std::iterator_traits to avoid problems with the name of
+// specialize thrust::iterator_traits to avoid problems with the name of
 // pointer's constructor shadowing its nested pointer type
 // do this before pointer is defined so the specialization is correctly
 // used inside the definition
-namespace std
+namespace thrust
 {
 
 template<typename Element>
@@ -65,7 +65,7 @@ template<typename Element>
     typedef typename ptr::reference               reference;
 }; // end iterator_traits
 
-} // end std
+} // end thrust
 
 /*! \endcond
  */

--- a/thrust/system/omp/memory.h
+++ b/thrust/system/omp/memory.h
@@ -44,11 +44,11 @@ template<typename> class pointer;
 /*! \cond
  */
 
-// specialize std::iterator_traits to avoid problems with the name of
+// specialize thrust::iterator_traits to avoid problems with the name of
 // pointer's constructor shadowing its nested pointer type
 // do this before pointer is defined so the specialization is correctly
 // used inside the definition
-namespace std
+namespace thrust
 {
 
 template<typename Element>
@@ -65,7 +65,7 @@ template<typename Element>
     typedef typename ptr::reference               reference;
 }; // end iterator_traits
 
-} // end std
+} // end thrust
 
 /*! \endcond
  */

--- a/thrust/system/tbb/memory.h
+++ b/thrust/system/tbb/memory.h
@@ -44,11 +44,11 @@ template<typename> class pointer;
 /*! \cond
  */
 
-// specialize std::iterator_traits to avoid problems with the name of
+// specialize thrust::iterator_traits to avoid problems with the name of
 // pointer's constructor shadowing its nested pointer type
 // do this before pointer is defined so the specialization is correctly
 // used inside the definition
-namespace std
+namespace thrust
 {
 
 template<typename Element>
@@ -65,7 +65,7 @@ template<typename Element>
     typedef typename ptr::reference               reference;
 }; // end iterator_traits
 
-} // end std
+} // end thrust
 
 /*! \endcond
  */


### PR DESCRIPTION
I simply implemented the standard for iterator_traits but in the thrust namespace.

I also updated the specializations for thrust::pointer iterators to use our new type
