### PR TITLE
Revert "Eliminate specializations of thrust::iterator_traits which are n...

### DIFF
--- a/thrust/detail/pointer.h
+++ b/thrust/detail/pointer.h
@@ -29,6 +29,37 @@ namespace thrust
 // declare pointer with default values of template parameters
 template<typename Element, typename Tag, typename Reference = use_default, typename Derived = use_default> class pointer;
 
+} // end thrust
+
+
+// specialize thrust::iterator_traits to avoid problems with the name of
+// pointer's constructor shadowing its nested pointer type
+// do this before pointer is defined so the specialization is correctly
+// used inside the definition
+namespace thrust
+{
+
+template<typename Element, typename Tag, typename Reference, typename Derived>
+  struct iterator_traits<thrust::pointer<Element,Tag,Reference,Derived> >
+{
+  private:
+    typedef thrust::pointer<Element,Tag,Reference,Derived> ptr;
+
+  public:
+    typedef typename ptr::iterator_category iterator_category;
+    typedef typename ptr::value_type        value_type;
+    typedef typename ptr::difference_type   difference_type;
+    // XXX implement this type (the result of operator->) later
+    typedef void                             pointer;
+    typedef typename ptr::reference         reference;
+}; // end iterator_traits
+
+} // end thrust
+
+
+namespace thrust
+{
+
 namespace detail
 {
 

--- a/thrust/system/cpp/memory.h
+++ b/thrust/system/cpp/memory.h
@@ -27,6 +27,49 @@
 #include <thrust/detail/allocator/malloc_allocator.h>
 #include <ostream>
 
+namespace thrust
+{
+namespace system
+{
+namespace cpp
+{
+
+template<typename> class pointer;
+
+} // end cpp
+} // end system
+} // end thrust
+
+
+/*! \cond
+ */
+
+// specialize thrust::iterator_traits to avoid problems with the name of
+// pointer's constructor shadowing its nested pointer type
+// do this before pointer is defined so the specialization is correctly
+// used inside the definition
+namespace thrust
+{
+
+template<typename Element>
+  struct iterator_traits<thrust::system::cpp::pointer<Element> >
+{
+  private:
+    typedef thrust::system::cpp::pointer<Element> ptr;
+
+  public:
+    typedef typename ptr::iterator_category       iterator_category;
+    typedef typename ptr::value_type              value_type;
+    typedef typename ptr::difference_type         difference_type;
+    typedef ptr                                   pointer;
+    typedef typename ptr::reference               reference;
+}; // end iterator_traits
+
+} // end thrust
+
+/*! \endcond
+ */
+
 
 namespace thrust
 {

--- a/thrust/system/cuda/memory.h
+++ b/thrust/system/cuda/memory.h
@@ -27,6 +27,49 @@
 #include <thrust/detail/allocator/malloc_allocator.h>
 #include <ostream>
 
+namespace thrust
+{
+namespace system
+{
+namespace cuda
+{
+
+template<typename> class pointer;
+
+} // end cuda
+} // end system
+} // end thrust
+
+
+/*! \cond
+ */
+
+// specialize thrust::iterator_traits to avoid problems with the name of
+// pointer's constructor shadowing its nested pointer type
+// do this before pointer is defined so the specialization is correctly
+// used inside the definition
+namespace thrust
+{
+
+template<typename Element>
+  struct iterator_traits<thrust::system::cuda::pointer<Element> >
+{
+  private:
+    typedef thrust::system::cuda::pointer<Element> ptr;
+
+  public:
+    typedef typename ptr::iterator_category       iterator_category;
+    typedef typename ptr::value_type              value_type;
+    typedef typename ptr::difference_type         difference_type;
+    typedef ptr                                   pointer;
+    typedef typename ptr::reference               reference;
+}; // end iterator_traits
+
+} // end thrust
+
+/*! \endcond
+ */
+
 
 namespace thrust
 {

--- a/thrust/system/omp/memory.h
+++ b/thrust/system/omp/memory.h
@@ -27,6 +27,49 @@
 #include <thrust/detail/allocator/malloc_allocator.h>
 #include <ostream>
 
+namespace thrust
+{
+namespace system
+{
+namespace omp
+{
+
+template<typename> class pointer;
+
+} // end omp
+} // end system
+} // end thrust
+
+
+/*! \cond
+ */
+
+// specialize thrust::iterator_traits to avoid problems with the name of
+// pointer's constructor shadowing its nested pointer type
+// do this before pointer is defined so the specialization is correctly
+// used inside the definition
+namespace thrust
+{
+
+template<typename Element>
+  struct iterator_traits<thrust::system::omp::pointer<Element> >
+{
+  private:
+    typedef thrust::system::omp::pointer<Element> ptr;
+
+  public:
+    typedef typename ptr::iterator_category       iterator_category;
+    typedef typename ptr::value_type              value_type;
+    typedef typename ptr::difference_type         difference_type;
+    typedef ptr                                   pointer;
+    typedef typename ptr::reference               reference;
+}; // end iterator_traits
+
+} // end thrust
+
+/*! \endcond
+ */
+
 
 namespace thrust
 {

--- a/thrust/system/tbb/memory.h
+++ b/thrust/system/tbb/memory.h
@@ -27,6 +27,49 @@
 #include <thrust/detail/allocator/malloc_allocator.h>
 #include <ostream>
 
+namespace thrust
+{
+namespace system
+{
+namespace tbb
+{
+
+template<typename> class pointer;
+
+} // end tbb
+} // end system
+} // end thrust
+
+
+/*! \cond
+ */
+
+// specialize thrust::iterator_traits to avoid problems with the name of
+// pointer's constructor shadowing its nested pointer type
+// do this before pointer is defined so the specialization is correctly
+// used inside the definition
+namespace thrust
+{
+
+template<typename Element>
+  struct iterator_traits<thrust::system::tbb::pointer<Element> >
+{
+  private:
+    typedef thrust::system::tbb::pointer<Element> ptr;
+
+  public:
+    typedef typename ptr::iterator_category       iterator_category;
+    typedef typename ptr::value_type              value_type;
+    typedef typename ptr::difference_type         difference_type;
+    typedef ptr                                   pointer;
+    typedef typename ptr::reference               reference;
+}; // end iterator_traits
+
+} // end thrust
+
+/*! \endcond
+ */
+
 
 namespace thrust
 {


### PR DESCRIPTION
Reverts thrust/thrust#547

Michael reports there are still problems on Windows, so I guess we still require these specializations.
