### PR TITLE
Use [push|pop]_macro pragmas only on gcc-4.4 and higher

### DIFF
--- a/thrust/system/cuda/detail/bulk/detail/guarded_cuda_runtime_api.hpp
+++ b/thrust/system/cuda/detail/bulk/detail/guarded_cuda_runtime_api.hpp
@@ -23,7 +23,7 @@
 // push_macro & pop_macro were introduced to gcc in version 4.3
 
 
-#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40300) || defined(__clang__)
+#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40400) || defined(__clang__)
 #  ifdef __host__
 #    pragma push_macro("__host__")
 #    undef __host__
@@ -40,7 +40,7 @@
 #include <cuda_runtime_api.h>
 
 
-#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40300) || defined(__clang__)
+#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40400) || defined(__clang__)
 #  ifdef BULK_HOST_NEEDS_RESTORATION
 #    pragma pop_macro("__host__")
 #    undef BULK_HOST_NEEDS_RESTORATION

--- a/thrust/system/cuda/detail/guarded_driver_types.h
+++ b/thrust/system/cuda/detail/guarded_driver_types.h
@@ -24,7 +24,7 @@
 // push_macro & pop_macro were introduced to gcc in version 4.3
 
 
-#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40300)
+#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40400)
 #  ifdef __host__
 #    pragma push_macro("__host__")
 #    undef __host__
@@ -41,7 +41,7 @@
 #include <driver_types.h>
 
 
-#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40300)
+#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40400)
 #  ifdef THRUST_HOST_NEEDS_RESTORATION
 #    pragma pop_macro("__host__")
 #    undef THRUST_HOST_NEEDS_RESTORATION


### PR DESCRIPTION
Otherwise, compilation on SLES11SP3(uses gcc-4.3.4) fails with the following error(s):
thrust/detail/internal_functional.h(441): error: identifier "**host**" is undefined
