### PR TITLE
Derive device iterator categories from

### DIFF
--- a/thrust/iterator/detail/iterator_category_with_system_and_traversal.h
+++ b/thrust/iterator/detail/iterator_category_with_system_and_traversal.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2008-2013 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+namespace thrust
+{
+namespace detail
+{
+
+
+template<typename Category, typename System, typename Traversal>
+  struct iterator_category_with_system_and_traversal
+    : Category
+{
+}; // end iterator_category_with_system_and_traversal
+
+
+// specialize iterator_category_to_system for iterator_category_with_system_and_traversal
+template<typename Category> struct iterator_category_to_system;
+
+template<typename Category, typename System, typename Traversal>
+  struct iterator_category_to_system<iterator_category_with_system_and_traversal<Category,System,Traversal> >
+{
+  typedef System type;
+}; // end iterator_category_to_system
+
+
+// specialize iterator_category_to_traversal for iterator_category_with_system_and_traversal
+template<typename Category> struct iterator_category_to_traversal;
+
+template<typename Category, typename System, typename Traversal>
+  struct iterator_category_to_traversal<iterator_category_with_system_and_traversal<Category,System,Traversal> >
+{
+  typedef Traversal type;
+}; // end iterator_category_to_traversal
+
+
+
+} // end detail
+} // end thrust
+

--- a/thrust/iterator/detail/iterator_facade_category.h
+++ b/thrust/iterator/detail/iterator_facade_category.h
@@ -24,6 +24,7 @@
 #include <thrust/iterator/iterator_categories.h>
 #include <thrust/iterator/detail/iterator_traversal_tags.h>
 #include <thrust/iterator/detail/is_iterator_category.h>
+#include <thrust/iterator/detail/iterator_category_with_system_and_traversal.h>
 #include <thrust/iterator/detail/iterator_category_to_traversal.h>
 
 namespace thrust
@@ -32,29 +33,6 @@ namespace thrust
 namespace detail
 {
 
-template<typename Category, typename System, typename Traversal>
-  struct iterator_category_with_system_and_traversal
-    : Category
-{
-}; // end iterator_category_with_system_and_traversal
-
-// specialize iterator_category_to_system for iterator_category_with_system_and_traversal
-template<typename Category> struct iterator_category_to_system;
-
-template<typename Category, typename System, typename Traversal>
-  struct iterator_category_to_system<iterator_category_with_system_and_traversal<Category,System,Traversal> >
-{
-  typedef System type;
-}; // end iterator_category_to_system
-
-// specialize iterator_category_to_traversal for iterator_category_with_system_and_traversal
-template<typename Category> struct iterator_category_to_traversal;
-
-template<typename Category, typename System, typename Traversal>
-  struct iterator_category_to_traversal<iterator_category_with_system_and_traversal<Category,System,Traversal> >
-{
-  typedef Traversal type;
-}; // end iterator_category_to_traversal
 
 // adapted from http://www.boost.org/doc/libs/1_37_0/libs/iterator/doc/iterator_facade.html#iterator-category
 //

--- a/thrust/iterator/iterator_categories.h
+++ b/thrust/iterator/iterator_categories.h
@@ -32,6 +32,8 @@
 #pragma once
 
 #include <thrust/detail/config.h>
+#include <thrust/iterator/detail/iterator_category_with_system_and_traversal.h>
+#include <thrust/iterator/detail/iterator_traversal_tags.h>
 
 // #include this for stl's iterator tags
 #include <iterator>
@@ -58,7 +60,13 @@ namespace thrust
  *  input_host_iterator_tag, output_host_iterator_tag, forward_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-struct input_device_iterator_tag {};
+struct input_device_iterator_tag
+  : thrust::detail::iterator_category_with_system_and_traversal<
+      std::input_iterator_tag,
+      thrust::device_system_tag,
+      thrust::single_pass_traversal_tag
+    >
+{};
 
 /*! \p output_device_iterator_tag is an empty class: it has no member functions,
  *  member variables, or nested types. It is used solely as a "tag": a
@@ -71,7 +79,13 @@ struct input_device_iterator_tag {};
  *  input_host_iterator_tag, output_host_iterator_tag, forward_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-struct output_device_iterator_tag {};
+struct output_device_iterator_tag
+  : thrust::detail::iterator_category_with_system_and_traversal<
+      std::output_iterator_tag,
+      thrust::device_system_tag,
+      thrust::single_pass_traversal_tag
+    >
+{};
 
 /*! \p forward_device_iterator_tag is an empty class: it has no member functions,
  *  member variables, or nested types. It is used solely as a "tag": a
@@ -84,7 +98,13 @@ struct output_device_iterator_tag {};
  *  input_host_iterator_tag, output_host_iterator_tag, forward_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-struct forward_device_iterator_tag : public input_device_iterator_tag {};
+struct forward_device_iterator_tag
+  : thrust::detail::iterator_category_with_system_and_traversal<
+      std::forward_iterator_tag,
+      thrust::device_system_tag,
+      thrust::forward_traversal_tag
+    >
+{};
 
 /*! \p bidirectional_device_iterator_tag is an empty class: it has no member
  *  functions, member variables, or nested types. It is used solely as a "tag": a
@@ -97,7 +117,13 @@ struct forward_device_iterator_tag : public input_device_iterator_tag {};
  *  input_host_iterator_tag, output_host_iterator_tag, forward_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-struct bidirectional_device_iterator_tag : public forward_device_iterator_tag {};
+struct bidirectional_device_iterator_tag
+  : thrust::detail::iterator_category_with_system_and_traversal<
+      std::bidirectional_iterator_tag,
+      thrust::device_system_tag,
+      thrust::bidirectional_traversal_tag
+    >
+{};
 
 /*! \p random_access_device_iterator_tag is an empty class: it has no member
  *  functions, member variables, or nested types. It is used solely as a "tag": a
@@ -110,7 +136,13 @@ struct bidirectional_device_iterator_tag : public forward_device_iterator_tag {}
  *  input_host_iterator_tag, output_host_iterator_tag, forward_host_iterator_tag,
  *  bidirectional_host_iterator_tag, random_access_host_iterator_tag
  */
-struct random_access_device_iterator_tag : public bidirectional_device_iterator_tag {};
+struct random_access_device_iterator_tag
+  : thrust::detail::iterator_category_with_system_and_traversal<
+      std::random_access_iterator_tag,
+      thrust::device_system_tag,
+      thrust::random_access_traversal_tag
+    >
+{};
 
 /*! \p input_host_iterator_tag is an empty class: it has no member
  *  functions, member variables, or nested types. It is used solely as a "tag": a


### PR DESCRIPTION
detail::iterator_category_with_system_and_traversal to satisfy libc++'s
implementation of std::iterator_traits' requirement that iterator
categories be convertible to standard iterator categories.

Fixes #581
