### PR TITLE
Fix build issues with GCC < 4.5

### DIFF
--- a/thrust/iterator/iterator_categories.h
+++ b/thrust/iterator/iterator_categories.h
@@ -34,6 +34,7 @@
 #include <thrust/detail/config.h>
 #include <thrust/iterator/detail/iterator_category_with_system_and_traversal.h>
 #include <thrust/iterator/detail/iterator_traversal_tags.h>
+#include <thrust/iterator/detail/device_system_tag.h>
 
 // #include this for stl's iterator tags
 #include <iterator>

--- a/thrust/system/cuda/detail/bulk/detail/guarded_cuda_runtime_api.hpp
+++ b/thrust/system/cuda/detail/bulk/detail/guarded_cuda_runtime_api.hpp
@@ -21,7 +21,7 @@
 // warnings from redefinitions of __host__ and __device__.
 // carefully save their definitions and restore them
 // can't tell exactly when push_macro & pop_macro were introduced to gcc; assume 4.5.0
-
+// for pre 4.5.0, fall back to old behavior (undefine __host__/__device__ if CUDA's host_defines has not been included)
 
 #if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40500) || defined(__clang__)
 #  ifdef __host__
@@ -34,6 +34,15 @@
 #    undef __device__
 #    define BULK_DEVICE_NEEDS_RESTORATION
 #  endif
+#else // GNUC pre 4.5.0
+#  if !defined(__HOST_DEFINES_H__)
+#    ifdef __host__
+#      undef __host__
+#    endif
+#    ifdef __device__
+#      undef __device__
+#    endif
+#  endif // __HOST_DEFINES_H_
 #endif // __GNUC__
 
 

--- a/thrust/system/cuda/detail/bulk/malloc.hpp
+++ b/thrust/system/cuda/detail/bulk/malloc.hpp
@@ -427,7 +427,7 @@ class singleton_on_chip_allocator
         void lock()
         {
           // spin while waiting
-          while(try_lock());
+          while(try_lock()) ;
         } // end lock()
 
 

--- a/thrust/system/cuda/detail/guarded_driver_types.h
+++ b/thrust/system/cuda/detail/guarded_driver_types.h
@@ -35,6 +35,15 @@
 #    undef __device__
 #    define THRUST_DEVICE_NEEDS_RESTORATION
 #  endif
+#else // GNUC pre 4.5.0
+#  if !defined(__DRIVER_TYPES_H__)
+#    ifdef __host__
+#      undef __host__
+#    endif
+#    ifdef __device__
+#      undef __device__
+#    endif
+#  endif // __DRIVER_TYPES_H__
 #endif // __GNUC__
 
 


### PR DESCRIPTION
- Space/or/Newline needed for loops with empty bodies
- **host** and **device** redefined due to push/pop macros not existing on GCC < 4.5.
- Missing #include for iterator_categories.
