### PR TITLE
GCC 4.3 does not do ADL correctly on malloc call

### DIFF
--- a/testing/memory.cu
+++ b/testing/memory.cu
@@ -198,8 +198,9 @@ template<typename T>
 
 void TestGetTemporaryBufferDispatchExplicit()
 {
-#if defined(THRUST_GCC_VERSION) && (THRUST_GCC_VERSION < 40300)
+#if defined(THRUST_GCC_VERSION) && (THRUST_GCC_VERSION <= 40300)
   // gcc 4.2 does not do adl correctly for get_temporary_buffer
+  // gcc 4.3 does not do adl correctly for malloc
   KNOWN_FAILURE;
 #else
   const size_t n = 9001;
@@ -233,8 +234,9 @@ void TestGetTemporaryBufferDispatchImplicit()
   }
   else
   {
-#if defined(THRUST_GCC_VERSION) && (THRUST_GCC_VERSION < 40300)
+#if defined(THRUST_GCC_VERSION) && (THRUST_GCC_VERSION <= 40300)
     // gcc 4.2 does not do adl correctly for get_temporary_buffer
+    // gcc 4.3 does not do adl correctly for malloc
     KNOWN_FAILURE;
 #else
     thrust::device_vector<int> vec(9001);


### PR DESCRIPTION
The tests call back into memory.cu for get_temporary_buffer (perfect, ADL works fine) but when it’s time to allocate memory, instead of going into thrust::system::cuda::detail::malloc<thrust::system::cuda::detail::tag>, it resolves the ADL to thrust::pointer<void,my_memory_system> malloc(my_memory_system &system, std::size_t) inside memory.cu (that malloc is used for validating the malloc dispatch unit test).

Since in GCC 4.4+ it resolves to the correct call, I am marking this as a compiler bug.