### PR TITLE
Implement CUDA's throw & termination functions directly with the functio...

### DIFF
--- a/thrust/detail/allocator/temporary_allocator.inl
+++ b/thrust/detail/allocator/temporary_allocator.inl
@@ -45,7 +45,7 @@ __host__ __device__
 #if !defined(__CUDA_ARCH__)
     throw thrust::system::detail::bad_alloc("temporary_buffer::allocate: get_temporary_buffer failed");
 #else
-    thrust::system::cuda::detail::terminate();
+    thrust::system::cuda::detail::terminate_with_message("temporary_buffer::allocate: get_temporary_buffer failed");
 #endif
   } // end if
 

--- a/thrust/system/cuda/detail/terminate.h
+++ b/thrust/system/cuda/detail/terminate.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <thrust/detail/config.h>
+#include <thrust/system/cuda/detail/bulk.h>
 
 namespace thrust
 {
@@ -31,9 +32,14 @@ namespace detail
 inline __device__
 void terminate()
 {
-#ifdef __CUDA_ARCH__
-  asm("trap;");
-#endif
+  thrust::system::cuda::detail::bulk_::detail::terminate();
+}
+
+
+__host__ __device__
+inline void terminate_with_message(const char* message)
+{
+  thrust::system::cuda::detail::bulk_::detail::terminate_with_message(message);
 }
 
 

--- a/thrust/system/cuda/detail/throw_on_error.h
+++ b/thrust/system/cuda/detail/throw_on_error.h
@@ -16,9 +16,7 @@
 
 #pragma once
 
-#include <thrust/system_error.h>
-#include <thrust/system/cuda/error.h>
-#include <thrust/system/cuda/detail/terminate.h>
+#include <thrust/detail/config.h>
 #include <thrust/system/cuda/detail/bulk.h>
 #include <cstdio>
 
@@ -36,19 +34,7 @@ namespace detail
 inline __host__ __device__
 void throw_on_error(cudaError_t error, const char *message)
 {
-  if(error)
-  {
-#ifndef __CUDA_ARCH__
-    throw thrust::system_error(error, thrust::cuda_category(), message);
-#else
-#  if (__BULK_HAS_PRINTF__ && __BULK_HAS_CUDART__)
-    printf("Error after %s: %s\n", message, cudaGetErrorString(error));
-#  elif __BULK_HAS_PRINTF__
-    printf("Error after %s\n", message);
-#  endif
-    thrust::system::cuda::detail::terminate();
-#endif
-  }
+  thrust::system::cuda::detail::bulk_::detail::throw_on_error(error, message);
 }
 
 


### PR DESCRIPTION
...ns in Bulk.

terminate_with_message() inside temporary_allocator::allocate() upon failure in __device__ code.

Fixes #630