### PR TITLE
Used UINT_MAX instead of std::numeric_limits to avoid __host__ __device_...

### DIFF
--- a/thrust/system/detail/generic/copy_if.inl
+++ b/thrust/system/detail/generic/copy_if.inl
@@ -25,6 +25,7 @@
 #include <thrust/distance.h>
 #include <thrust/transform.h>
 #include <thrust/detail/internal_functional.h>
+#include <thrust/detail/integer_traits.h>
 #include <thrust/detail/temporary_array.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/scan.h>
@@ -140,7 +141,7 @@ __host__ __device__
   typename thrust::detail::make_unsigned<difference_type>::type unsigned_n(n);
   
   // use 32-bit indices when possible (almost always)
-  if(sizeof(difference_type) > sizeof(unsigned int) && unsigned_n > UINT_MAX)
+  if(sizeof(difference_type) > sizeof(unsigned int) && unsigned_n > thrust::detail::integer_traits<unsigned int>::const_max)
   {
     result = detail::copy_if<difference_type>(exec, first, last, stencil, result, pred);
   } // end if

--- a/thrust/system/detail/generic/copy_if.inl
+++ b/thrust/system/detail/generic/copy_if.inl
@@ -140,7 +140,7 @@ __host__ __device__
   typename thrust::detail::make_unsigned<difference_type>::type unsigned_n(n);
   
   // use 32-bit indices when possible (almost always)
-  if(sizeof(difference_type) > sizeof(unsigned int) && unsigned_n > (std::numeric_limits<unsigned int>::max)())
+  if(sizeof(difference_type) > sizeof(unsigned int) && unsigned_n > UINT_MAX)
   {
     result = detail::copy_if<difference_type>(exec, first, last, stencil, result, pred);
   } // end if


### PR DESCRIPTION
..._ warning

The following code issues a warning when the device backend is set to OMP.

```shell
/usr/local/cuda/include/thrust/system/detail/generic/copy_if.inl(143): warning: calling a __host__ function from a __host__ __device__ function is not allowed
```

This update replaces std::numeric_limits<unsigned int>::max with UINT_MAX to silence the warning.

```c++
#include <thrust/device_vector.h>
#include <thrust/copy.h>

int main(void)
{
    thrust::device_vector<int> A;
    thrust::device_vector<bool> stencil;

    thrust::copy_if(A.begin(), A.end(), A.begin(), thrust::identity<bool>());

    return 0;
}
```