### PR TITLE
Silence host device warnings in the functor used in count_if's

### DIFF
--- a/thrust/system/detail/generic/count.inl
+++ b/thrust/system/detail/generic/count.inl
@@ -35,6 +35,7 @@ struct count_if_transform
   __host__ __device__ 
   count_if_transform(Predicate _pred) : pred(_pred){}
 
+  __thrust_hd_warning_disable__
   __host__ __device__
   CountType operator()(const InputType& val)
   {


### PR DESCRIPTION
implementation

Fixes #647