### PR TITLE
Stream operator<< for device_reference

### DIFF
--- a/thrust/complex.h
+++ b/thrust/complex.h
@@ -541,8 +541,9 @@ template <typename T> __host__ __device__ complex<T> atanh(const complex<T>& z);
  *  \param os The output stream.
  *  \param z The \p complex number to output.
  */
-template<typename ValueType,class charT, class traits>
-std::basic_ostream<charT, traits>& operator<<(std::basic_ostream<charT, traits>& os, const complex<ValueType>& z);
+template<typename ValueType, typename charT, typename traits>
+std::basic_ostream<charT, traits>&
+operator<<(std::basic_ostream<charT, traits>& os, const complex<ValueType>& z);
 
 /*! Reads a \p complex number from an input stream.
  *  The recognized formats are:
@@ -555,7 +556,7 @@ std::basic_ostream<charT, traits>& operator<<(std::basic_ostream<charT, traits>&
  *  \param is The input stream.
  *  \param z The \p complex number to set.
  */
-template<typename ValueType, typename charT, class traits>
+template<typename ValueType, typename charT, typename traits>
 std::basic_istream<charT, traits>&
 operator>>(std::basic_istream<charT, traits>& is, complex<ValueType>& z);
 
@@ -614,4 +615,3 @@ template <typename T> __host__ __device__ inline bool operator!=(const complex<T
 
 /*! \} // numerics
  */
-

--- a/thrust/complex.h
+++ b/thrust/complex.h
@@ -615,3 +615,4 @@ template <typename T> __host__ __device__ inline bool operator!=(const complex<T
 
 /*! \} // numerics
  */
+

--- a/thrust/detail/device_ptr.inl
+++ b/thrust/detail/device_ptr.inl
@@ -21,7 +21,6 @@
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_reference.h>
-#include <iostream>
 
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/iterator_traits.h>
@@ -40,13 +39,6 @@ template<typename T>
 {
   return ptr;
 } // end device_pointer_cast()
-
-// output to ostream
-template<class E, class T, class Y>
-  std::basic_ostream<E, T> &operator<<(std::basic_ostream<E, T> &os, const device_ptr<Y> &p)
-{
-  return os << p.get();
-} // end operator<<()
 
 
 namespace detail
@@ -71,4 +63,3 @@ template<typename T>
 
 } // end namespace detail
 } // end namespace thrust
-

--- a/thrust/detail/device_ptr.inl
+++ b/thrust/detail/device_ptr.inl
@@ -21,7 +21,6 @@
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_reference.h>
-
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/iterator_traits.h>
 
@@ -63,3 +62,4 @@ template<typename T>
 
 } // end namespace detail
 } // end namespace thrust
+

--- a/thrust/detail/device_reference.inl
+++ b/thrust/detail/device_reference.inl
@@ -50,4 +50,3 @@ void swap(device_reference<T> &a, device_reference<T> &b)
 } // end swap()
 
 } // end thrust
-

--- a/thrust/detail/device_reference.inl
+++ b/thrust/detail/device_reference.inl
@@ -50,3 +50,4 @@ void swap(device_reference<T> &a, device_reference<T> &b)
 } // end swap()
 
 } // end thrust
+

--- a/thrust/detail/pointer.h
+++ b/thrust/detail/pointer.h
@@ -24,6 +24,7 @@
 #include <thrust/detail/reference_forward_declaration.h>
 #include <ostream>
 
+
 namespace thrust
 {
 
@@ -189,3 +190,4 @@ operator<<(std::basic_ostream<charT, traits> &os,
 } // end thrust
 
 #include <thrust/detail/pointer.inl>
+

--- a/thrust/detail/pointer.h
+++ b/thrust/detail/pointer.h
@@ -22,6 +22,7 @@
 #include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/reference_forward_declaration.h>
+#include <ostream>
 
 namespace thrust
 {
@@ -178,7 +179,13 @@ template<typename Element, typename Tag, typename Reference, typename Derived>
     Element *get() const;
 }; // end pointer
 
+// Output stream operator
+template<typename Element, typename Tag, typename Reference, typename Derived,
+         typename charT, typename traits>
+std::basic_ostream<charT, traits> &
+operator<<(std::basic_ostream<charT, traits> &os,
+           const pointer<Element, Tag, Reference, Derived> &p);
+
 } // end thrust
 
 #include <thrust/detail/pointer.inl>
-

--- a/thrust/detail/pointer.inl
+++ b/thrust/detail/pointer.inl
@@ -147,3 +147,4 @@ template<typename Element, typename Tag, typename Reference, typename Derived, t
 
 
 } // end thrust
+

--- a/thrust/detail/pointer.inl
+++ b/thrust/detail/pointer.inl
@@ -80,6 +80,13 @@ template<typename Element, typename Tag, typename Reference, typename Derived>
   return super_t::base();
 } // end pointer::get
 
+template<typename Element, typename Tag, typename Reference, typename Derived,
+         typename charT, typename traits>
+std::basic_ostream<charT, traits> &
+operator<<(std::basic_ostream<charT, traits> &os,
+           const pointer<Element, Tag, Reference, Derived> &p) {
+  return os << p.get();
+}
 
 namespace detail
 {
@@ -140,4 +147,3 @@ template<typename Element, typename Tag, typename Reference, typename Derived, t
 
 
 } // end thrust
-

--- a/thrust/detail/reference.h
+++ b/thrust/detail/reference.h
@@ -20,7 +20,7 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/use_default.h>
 #include <thrust/detail/reference_forward_declaration.h>
-
+#include <ostream>
 
 namespace thrust
 {
@@ -160,8 +160,13 @@ template<typename Element, typename Pointer, typename Derived>
     value_type convert_to_value_type(System *system) const;
 }; // end reference
 
-  
+// Output stream operator
+template<typename Element, typename Pointer, typename Derived,
+         typename charT, typename traits>
+std::basic_ostream<charT, traits> &
+operator<<(std::basic_ostream<charT, traits> &os,
+           const reference<Element, Pointer, Derived> &y);
+
 } // end thrust
 
 #include <thrust/detail/reference.inl>
-

--- a/thrust/detail/reference.h
+++ b/thrust/detail/reference.h
@@ -22,6 +22,7 @@
 #include <thrust/detail/reference_forward_declaration.h>
 #include <ostream>
 
+
 namespace thrust
 {
 namespace detail
@@ -170,3 +171,4 @@ operator<<(std::basic_ostream<charT, traits> &os,
 } // end thrust
 
 #include <thrust/detail/reference.inl>
+

--- a/thrust/detail/reference.inl
+++ b/thrust/detail/reference.inl
@@ -72,7 +72,7 @@ template<typename Element, typename Pointer, typename Derived>
     reference<Element,Pointer,Derived>
       ::operator=(const reference &other)
 {
-  assign_from(&other); 
+  assign_from(&other);
   return static_cast<derived_type&>(*this);
 } // end reference::operator=()
 
@@ -356,6 +356,13 @@ template<typename Element, typename Pointer, typename Derived>
   return static_cast<derived_type&>(*this);
 } // end reference::operator^=()
 
-  
-} // end thrust
+template<typename Element, typename Pointer, typename Derived,
+         typename charT, typename traits>
+std::basic_ostream<charT, traits> &
+operator<<(std::basic_ostream<charT, traits> &os,
+           const reference<Element, Pointer, Derived> &y) {
+  typedef typename reference<Element, Pointer, Derived>::value_type value_type;
+  return os << static_cast<value_type>(y);
+} // end operator<<()
 
+} // end thrust

--- a/thrust/detail/reference.inl
+++ b/thrust/detail/reference.inl
@@ -72,7 +72,7 @@ template<typename Element, typename Pointer, typename Derived>
     reference<Element,Pointer,Derived>
       ::operator=(const reference &other)
 {
-  assign_from(&other);
+  assign_from(&other); 
   return static_cast<derived_type&>(*this);
 } // end reference::operator=()
 

--- a/thrust/device_ptr.h
+++ b/thrust/device_ptr.h
@@ -171,3 +171,4 @@ inline device_ptr<T> device_pointer_cast(const device_ptr<T> &ptr);
 
 #include <thrust/detail/device_ptr.inl>
 #include <thrust/detail/raw_pointer_cast.h>
+

--- a/thrust/device_ptr.h
+++ b/thrust/device_ptr.h
@@ -23,7 +23,6 @@
 
 #include <thrust/detail/config.h>
 #include <thrust/memory.h>
-#include <ostream>
 
 namespace thrust
 {
@@ -121,14 +120,19 @@ template<typename T>
 #endif // end doxygen-only members
 }; // end device_ptr
 
-/*! This operator outputs the value of a \p device_ptr's raw pointer to a \p std::basic_ostream.
+// declare these methods for the purpose of Doxygenating them
+// they actually are defined for a derived-from class
+#if 0
+/*! Writes to an output stream the value of a \p device_ptr's raw pointer.
  *
- *  \param os The std::basic_ostream of interest.
- *  \param p The device_ptr of interest.
+ *  \param os The output stream.
+ *  \param p The \p device_ptr to output.
  *  \return os.
  */
-template<class E, class T, class Y>
-inline std::basic_ostream<E, T> &operator<<(std::basic_ostream<E, T> &os, const device_ptr<Y> &p);
+template<typename T, typename charT, typename traits>
+std::basic_ostream<charT, traits> &
+operator<<(std::basic_ostream<charT, traits> &os, const device_ptr<T> &p);
+#endif
 
 /*! \}
  */
@@ -167,4 +171,3 @@ inline device_ptr<T> device_pointer_cast(const device_ptr<T> &ptr);
 
 #include <thrust/detail/device_ptr.inl>
 #include <thrust/detail/raw_pointer_cast.h>
-

--- a/thrust/device_reference.h
+++ b/thrust/device_reference.h
@@ -960,10 +960,23 @@ template<typename T>
 __host__ __device__
 void swap(device_reference<T> &x, device_reference<T> &y);
 
+// declare these methods for the purpose of Doxygenating them
+// they actually are defined for a derived-from class
+#if 0
+/*! Writes to an output stream the value of a \p device_reference.
+ *
+ *  \param os The output stream.
+ *  \param y The \p device_reference to output.
+ *  \return os.
+ */
+template<typename T, typename charT, typename traits>
+std::basic_ostream<charT, traits> &
+operator<<(std::basic_ostream<charT, traits> &os, const device_reference<T> &y);
+#endif
+
 /*! \}
  */
 
 } // end thrust
 
 #include <thrust/detail/device_reference.inl>
-

--- a/thrust/device_reference.h
+++ b/thrust/device_reference.h
@@ -980,3 +980,4 @@ operator<<(std::basic_ostream<charT, traits> &os, const device_reference<T> &y);
 } // end thrust
 
 #include <thrust/detail/device_reference.inl>
+


### PR DESCRIPTION
Implicit conversions are not considered during template argument deduction. Currently, stream output of a `device_reference<A>` where `A` is non-template (e.g. `int`, `float`, `double`, `mystruct`) functions as expected, but fails when `A` is a template (e.g. `thrust::complex<float>`, `mytemplate<int>`).

Example:

```
#include <thrust/device_vector.h>
#include <thrust/complex.h>
#include <iostream>

int main() {
  thrust::device_vector<double> a(5);
  std::cout << a[2] << std::endl;   // Outputs '0' as expected

  thrust::device_vector<thrust::complex<double> > b(5);
  std::cout << b[2] << std::endl;   // XXX: Fails to compile despite operator<< being defined for thrust::complex<T>
}
```

This patch simply uses `static_cast` to force the conversion and mirrors `operator<<` defined for `device_ptr<T>`.