### PR TITLE
remove the need to derive from thrust::unary_function/thrust::binary_function when c++11 is enabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,33 @@
 #######################################
+#           Thrust v1.9.0             #
+#######################################
+
+Summary
+    TODO
+
+Breaking API Changes
+    None.
+
+New Features
+    TODO
+
+New Examples
+    TODO
+
+Other Enhancements
+    If C++11 support is enabled, functors do not have to inherit from thrust::unary_function/thrust::binary_function anymore when using them with thrust::transform_iterator.
+
+Bug Fixes
+    TODO
+
+Known Issues
+    TODO
+
+Acknowledgments
+    Thanks to Manuel Schiller for contributing a C++11 based enhancement regarding the deduction of functor return types.
+    
+
+#######################################
 #           Thrust v1.8.2             #
 #######################################
 

--- a/SConstruct
+++ b/SConstruct
@@ -321,9 +321,8 @@ def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_al
   # workarounds
   result.extend(flags['workarounds'])
 
-  # select C++ standard, only set -std=... if we did not yet set it via nvcc
-  if device_backend != 'cuda':
-    result.extend(flags[cpp_standard])
+  # select C++ standard
+  result.extend(flags[cpp_standard])
 
   return result
 

--- a/SConstruct
+++ b/SConstruct
@@ -314,7 +314,7 @@ def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_al
 
   # workarounds
   result.extend(flags['workarounds'])
-  
+
   return result
 
 

--- a/SConstruct
+++ b/SConstruct
@@ -35,7 +35,9 @@ gnu_compiler_flags = {
   'omp'                : ['-fopenmp'],
   'tbb'                : [],
   'cuda'               : [],
-  'workarounds'        : []
+  'workarounds'        : [],
+  'c++03'              : [],
+  'c++11'              : ['-std=c++11']
 }
 
 clang_compiler_flags = {
@@ -48,7 +50,9 @@ clang_compiler_flags = {
   'omp'                : ['-fopenmp'],
   'tbb'                : [],
   'cuda'               : [],
-  'workarounds'        : []
+  'workarounds'        : [],
+  'c++03'              : [],
+  'c++11'              : ['-std=c++11']
 }
 
 msvc_compiler_flags = {
@@ -64,7 +68,9 @@ msvc_compiler_flags = {
 
   # avoid min/max problems due to windows.h
   # suppress warnings due to "decorated name length exceeded"
-  'workarounds'        : ['/DNOMINMAX', '/wd4503']
+  'workarounds'        : ['/DNOMINMAX', '/wd4503'],
+  'c++03'              : [],
+  'c++11'              : []
 }
 
 compiler_to_flags = {
@@ -281,7 +287,7 @@ def macros(mode, host_backend, device_backend):
   return result
 
 
-def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_all, warnings_as_errors):
+def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_all, warnings_as_errors, cpp_standard):
   """Returns a list of command line flags needed by the c or c++ compiler"""
   # start with all platform-independent preprocessor macros
   result = macros(mode, host_backend, device_backend)
@@ -315,10 +321,13 @@ def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_al
   # workarounds
   result.extend(flags['workarounds'])
 
+  # select C++ standard
+  result.extend(flags[cpp_standard])
+  
   return result
 
 
-def nv_compiler_flags(mode, device_backend, arch, cdp):
+def nv_compiler_flags(mode, device_backend, arch, cdp, cpp_standard):
   """Returns a list of command line flags specific to nvcc"""
   result = []
   for machine_arch in arch:
@@ -344,6 +353,10 @@ def nv_compiler_flags(mode, device_backend, arch, cdp):
       result.append('-ccbin')
       result.append(master_env.subst('$CXX'))
 
+  # select C++ standard
+  if cpp_standard == 'c++11':
+    result.append("-std=c++11")
+  
   return result
 
 
@@ -381,6 +394,10 @@ def command_line_variables():
   
   # add a variable to treat warnings as errors
   vars.Add(BoolVariable('Werror', 'Treat warnings as errors', os.name != 'nt'))
+  
+  # add a variable to switch between C++ standards
+  vars.Add(EnumVariable('std', 'C++ standard', 'c++03',
+                        allowed_values = ('c++03', 'c++11')))
 
   return vars
 
@@ -435,9 +452,9 @@ for (host,device) in itertools.product(host_backends, device_backends):
   # populate the environment
   env.Append(CPPPATH = inc_paths(env, host, device))
   
-  env.Append(CCFLAGS = cc_compiler_flags(env.subst('$CXX'), env['mode'], env['PLATFORM'], host, device, env['Wall'], env['Werror']))
+  env.Append(CCFLAGS = cc_compiler_flags(env.subst('$CXX'), env['mode'], env['PLATFORM'], host, device, env['Wall'], env['Werror'], env['std']))
   
-  env.Append(NVCCFLAGS = nv_compiler_flags(env['mode'], device, env['arch'], env['cdp']))
+  env.Append(NVCCFLAGS = nv_compiler_flags(env['mode'], device, env['arch'], env['cdp'], env['std']))
   
   env.Append(LIBS = libs(env, env.subst('$CXX'), host, device))
 

--- a/SConstruct
+++ b/SConstruct
@@ -35,9 +35,7 @@ gnu_compiler_flags = {
   'omp'                : ['-fopenmp'],
   'tbb'                : [],
   'cuda'               : [],
-  'workarounds'        : [],
-  'c++03'              : [],
-  'c++11'              : ['-std=c++11']
+  'workarounds'        : []
 }
 
 clang_compiler_flags = {
@@ -50,9 +48,7 @@ clang_compiler_flags = {
   'omp'                : ['-fopenmp'],
   'tbb'                : [],
   'cuda'               : [],
-  'workarounds'        : [],
-  'c++03'              : [],
-  'c++11'              : ['-std=c++11']
+  'workarounds'        : []
 }
 
 msvc_compiler_flags = {
@@ -68,9 +64,7 @@ msvc_compiler_flags = {
 
   # avoid min/max problems due to windows.h
   # suppress warnings due to "decorated name length exceeded"
-  'workarounds'        : ['/DNOMINMAX', '/wd4503'],
-  'c++03'              : [],
-  'c++11'              : []
+  'workarounds'        : ['/DNOMINMAX', '/wd4503']
 }
 
 compiler_to_flags = {
@@ -287,7 +281,7 @@ def macros(mode, host_backend, device_backend):
   return result
 
 
-def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_all, warnings_as_errors, cpp_standard):
+def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_all, warnings_as_errors):
   """Returns a list of command line flags needed by the c or c++ compiler"""
   # start with all platform-independent preprocessor macros
   result = macros(mode, host_backend, device_backend)
@@ -320,9 +314,6 @@ def cc_compiler_flags(CXX, mode, platform, host_backend, device_backend, warn_al
 
   # workarounds
   result.extend(flags['workarounds'])
-
-  # select C++ standard
-  result.extend(flags[cpp_standard])
   
   return result
 
@@ -452,7 +443,7 @@ for (host,device) in itertools.product(host_backends, device_backends):
   # populate the environment
   env.Append(CPPPATH = inc_paths(env, host, device))
   
-  env.Append(CCFLAGS = cc_compiler_flags(env.subst('$CXX'), env['mode'], env['PLATFORM'], host, device, env['Wall'], env['Werror'], env['std']))
+  env.Append(CCFLAGS = cc_compiler_flags(env.subst('$CXX'), env['mode'], env['PLATFORM'], host, device, env['Wall'], env['Werror']))
   
   env.Append(NVCCFLAGS = nv_compiler_flags(env['mode'], device, env['arch'], env['cdp'], env['std']))
   

--- a/examples/cuda/async_reduce.cu
+++ b/examples/cuda/async_reduce.cu
@@ -58,12 +58,12 @@ int main()
   // copy all the algorithm parameters
   auto begin     = data.begin();
   auto end       = data.end();
-  auto init      = 0;
-  auto binary_op = thrust::plus<int>();
+  unsigned int init      = 0;
+  auto binary_op = thrust::plus<unsigned int>();
 
   // std::async captures the algorithm parameters by value
   // use std::launch::async to ensure the creation of a new thread
-  std::future<int> future_result = std::async(std::launch::async, [=]
+  std::future<unsigned int> future_result = std::async(std::launch::async, [=]
   {
     return thrust::reduce(begin, end, init, binary_op);
   });

--- a/thrust/detail/type_traits/result_of.h
+++ b/thrust/detail/type_traits/result_of.h
@@ -20,7 +20,7 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/type_traits/function_traits.h>
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || defined(__cpp_lib_result_of_sfinae)
 // necessary for std::result_of
 #include <type_traits>
 #endif
@@ -30,7 +30,7 @@ namespace thrust
 namespace detail
 {
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || defined(__cpp_lib_result_of_sfinae)
 
 template<typename Signature>
   struct result_of

--- a/thrust/detail/type_traits/result_of.h
+++ b/thrust/detail/type_traits/result_of.h
@@ -35,7 +35,7 @@ namespace detail
 template<typename Signature>
   struct result_of
 {
-  using type = typename std::result_of<Signature>::type;
+  typedef typename std::result_of<Signature>::type type;
 };
 
 #else

--- a/thrust/detail/type_traits/result_of.h
+++ b/thrust/detail/type_traits/result_of.h
@@ -20,6 +20,11 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/type_traits/function_traits.h>
 
+#if __cplusplus >= 201103L
+// necessary for std::result_of
+#include <type_traits>
+#endif
+
 namespace thrust
 {
 namespace detail
@@ -30,7 +35,7 @@ namespace detail
 template<typename Signature>
   struct result_of
 {
-  typedef typename std::result_of<Signature>::type type;
+  using type = typename std::result_of<Signature>::type;
 };
 
 #else

--- a/thrust/detail/type_traits/result_of.h
+++ b/thrust/detail/type_traits/result_of.h
@@ -25,6 +25,16 @@ namespace thrust
 namespace detail
 {
 
+#if __cplusplus >= 201103L
+
+template<typename Signature>
+  struct result_of
+{
+  typedef typename std::result_of<Signature>::type type;
+};
+
+#else
+
 template<typename Signature, typename Enable = void> struct result_of;
 
 // specialization for unary invocations of things which have result_type
@@ -46,6 +56,8 @@ template<typename Functor, typename Arg1, typename Arg2>
 {
   typedef typename Functor::result_type type;
 };
+
+#endif // __cplusplus >= 201103L
 
 } // end detail
 } // end thrust

--- a/thrust/functional.h
+++ b/thrust/functional.h
@@ -58,7 +58,9 @@ template<typename Operation> struct binary_traits;
  *  };
  *  \endcode
  *
- *  \note Inheriting from unary_function is optional if C+11 support is enabled.
+ *  \note Because C++11 language support makes the functionality of
+ *        \c unary_function obsolete, it's use is optional if C++11 language
+ *        features are enabled.
  *
  *  \see http://www.sgi.com/tech/stl/unary_function.html
  *  \see binary_function
@@ -96,7 +98,9 @@ struct unary_function
  *  };
  *  \endcode
  *
- *  \note Inheriting from binary_function is optional if C+11 support is enabled.
+ *  \note Because C++11 language support makes the functionality of
+ *        \c binary_function obsolete, it's use is optional if C++11 language
+ *        features are enabled.
  *
  *  \see http://www.sgi.com/tech/stl/binary_function.html
  *  \see unary_function

--- a/thrust/functional.h
+++ b/thrust/functional.h
@@ -58,9 +58,7 @@ template<typename Operation> struct binary_traits;
  *  };
  *  \endcode
  *
- *  \note unary_function is currently redundant with the C++ STL type
- *  \c std::unary_function. We reserve it here for potential additional
- *  functionality at a later date.
+ *  \note Inheriting from unary_function is optional if C+11 support is enabled.
  *
  *  \see http://www.sgi.com/tech/stl/unary_function.html
  *  \see binary_function
@@ -98,9 +96,7 @@ struct unary_function
  *  };
  *  \endcode
  *
- *  \note binary_function is currently redundant with the C++ STL type
- *  \c std::binary_function. We reserve it here for potential additional
- *  functionality at a later date.
+ *  \note Inheriting from binary_function is optional if C+11 support is enabled.
  *
  *  \see http://www.sgi.com/tech/stl/binary_function.html
  *  \see unary_function


### PR DESCRIPTION
see #624 
