### PR TITLE
Use #pragma hd_warning_disable to accomodate older nvcc.

### DIFF
--- a/thrust/detail/config/exec_check_disable.h
+++ b/thrust/detail/config/exec_check_disable.h
@@ -25,6 +25,7 @@
 #if defined(__CUDACC__)
 
 #define __thrust_exec_check_disable__ \
+#pragma hd_warning_disable \
 #pragma nv_exec_check_disable
 #else
 


### PR DESCRIPTION
Fixes #688