### PR TITLE
Fix printf calls in some examples.

### DIFF
--- a/thrust/for_each.h
+++ b/thrust/for_each.h
@@ -136,7 +136,7 @@ InputIterator for_each(const thrust::detail::execution_policy_base<DerivedPolicy
  *      // note that using printf in a __device__ function requires
  *      // code compiled for a GPU with compute capability 2.0 or
  *      // higher (nvcc --arch=sm_20)
- *      printf("%d\n");
+ *      printf("%d\n", x);
  *    }
  *  };
  *  ...
@@ -194,7 +194,7 @@ InputIterator for_each_n(const thrust::detail::execution_policy_base<DerivedPoli
  *      // note that using printf in a __device__ function requires
  *      // code compiled for a GPU with compute capability 2.0 or
  *      // higher (nvcc --arch=sm_20)
- *      printf("%d\n");
+ *      printf("%d\n", x);
  *    }
  *  };
  *  ...
@@ -249,7 +249,7 @@ InputIterator for_each(InputIterator first,
  *      // note that using printf in a __device__ function requires
  *      // code compiled for a GPU with compute capability 2.0 or
  *      // higher (nvcc --arch=sm_20)
- *      printf("%d\n");
+ *      printf("%d\n", x);
  *    }
  *  };
  *  ...

--- a/thrust/system/cpp/execution_policy.h
+++ b/thrust/system/cpp/execution_policy.h
@@ -130,7 +130,7 @@ struct tag : thrust::system::cpp::execution_policy<tag> { unspecified };
  *    __host__ __device__
  *    void operator()(int x)
  *    {
- *      printf("%d\n");
+ *      printf("%d\n", x);
  *    }
  *  };
  *  ...

--- a/thrust/system/cuda/execution_policy.h
+++ b/thrust/system/cuda/execution_policy.h
@@ -138,7 +138,7 @@ struct tag : thrust::system::cuda::execution_policy<tag> { unspecified };
  *    __host__ __device__
  *    void operator()(int x)
  *    {
- *      printf("%d\n");
+ *      printf("%d\n", x);
  *    }
  *  };
  *  ...

--- a/thrust/system/omp/execution_policy.h
+++ b/thrust/system/omp/execution_policy.h
@@ -129,7 +129,7 @@ struct tag : thrust::system::omp::execution_policy<tag> { unspecified };
  *    __host__ __device__
  *    void operator()(int x)
  *    {
- *      printf("%d\n");
+ *      printf("%d\n", x);
  *    }
  *  };
  *  ...

--- a/thrust/system/tbb/execution_policy.h
+++ b/thrust/system/tbb/execution_policy.h
@@ -129,7 +129,7 @@ struct tag : thrust::system::tbb::execution_policy<tag> { unspecified };
  *    __host__ __device__
  *    void operator()(int x)
  *    {
- *      printf("%d\n");
+ *      printf("%d\n", x);
  *    }
  *  };
  *  ...


### PR DESCRIPTION
Some of the provided example usage snippets use incorrect `printf` calls, `printf("%d\n");`, with no variable being printed.

If using the code verbatim, compiling gives a warning, and running results in an error:

Minimal example:

```{c++}
struct printf_functor
{
  __host__ __device__
  void operator()(int x)
  {
    // note that using printf in a __device__ function requires
    // code compiled for a GPU with compute capability 2.0 or
    // higher (nvcc --arch=sm_20)
    printf("%d\n"); // Nothing to print, x is missing
  }
};

int main(int argc, char **argv) {


	thrust::device_vector<int> d_vec(3);
	d_vec[0] = 0; d_vec[1] = 1; d_vec[2] = 2;
	thrust::for_each(d_vec.begin(), d_vec.end(), printf_functor());

	return 0;

}

```

```
> make example
 warning: format ‘%d’ expects a matching ‘int’ argument [-Wformat=]
     printf("%d\n");
```

And attempting to run the code results in an error:
```
> ./example.o
terminate called after throwing an instance of 'thrust::system::system_error'
  what():  cudaFree in free: an illegal memory access was encountered
```

This adds the variable to print in the printf calls, making the examples correct.