### PR TITLE
add new "fancy" iterator: transform_output_iterator

### DIFF
--- a/thrust/iterator/detail/transform_output_iterator.inl
+++ b/thrust/iterator/detail/transform_output_iterator.inl
@@ -1,0 +1,53 @@
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/iterator/iterator_adaptor.h>
+
+namespace thrust
+{
+
+template <typename OutputIterator, typename UnaryFunction>
+  class transform_output_iterator;
+
+namespace detail 
+{
+
+template <typename UnaryFunction, typename OutputIterator>
+  class transform_output_iterator_proxy
+{
+
+  public:
+    __host__ __device__
+    transform_output_iterator_proxy(const OutputIterator& out, UnaryFunction fun) : fun(fun), out(out)
+    {
+    }
+
+    template <typename T>
+    __host__ __device__
+    transform_output_iterator_proxy operator=(const T& x)
+    {
+      *out = fun(x);
+      return *this;
+    }
+
+  private:
+    OutputIterator out;
+    UnaryFunction fun;
+};
+
+// Compute the iterator_adaptor instantiation to be used for transform_output_iterator
+template <typename UnaryFunction, typename OutputIterator>
+struct transform_output_iterator_base
+{
+    typedef thrust::iterator_adaptor
+    <
+        transform_output_iterator<UnaryFunction, OutputIterator>
+      , OutputIterator
+      , thrust::use_default
+      , thrust::use_default
+      , thrust::use_default
+      , transform_output_iterator_proxy<UnaryFunction, OutputIterator>
+    > type;
+};
+
+} // end detail
+} // end thrust
+

--- a/thrust/iterator/transform_output_iterator.h
+++ b/thrust/iterator/transform_output_iterator.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <thrust/detail/config.h>
+#include <thrust/iterator/detail/transform_output_iterator.inl>
+
+namespace thrust
+{
+
+template <typename UnaryFunction, typename OutputIterator>
+  class transform_output_iterator
+    : public detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type
+{
+
+  public:
+
+    typedef typename
+    detail::transform_output_iterator_base<UnaryFunction, OutputIterator>::type
+    super_t;
+
+    friend class thrust::iterator_core_access;
+
+    __host__ __device__
+    transform_output_iterator(const OutputIterator& out, UnaryFunction fun) : super_t(out), fun(fun)
+    {
+    }
+
+  private:
+
+    __host__ __device__
+    typename super_t::reference dereference() const
+    {
+        return detail::transform_output_iterator_proxy<UnaryFunction, OutputIterator>(this->base_reference(), fun);
+    }
+
+    UnaryFunction fun;
+
+}; // end transform_output_iterator
+
+
+template <typename UnaryFunction, typename OutputIterator>
+transform_output_iterator<UnaryFunction, OutputIterator>
+__host__ __device__
+make_transform_output_iterator(OutputIterator out, UnaryFunction fun)
+{
+    return transform_output_iterator<UnaryFunction, OutputIterator>(out, fun);
+} // end make_transform_output_iterator
+
+ 
+} // end thrust
+


### PR DESCRIPTION
When answering [this stackoverflow question](http://stackoverflow.com/a/34424403/678093) I ported `transform_output_iterator` from [here](https://github.com/ldionne/boost-submissions/blob/master/boost/boost/iterator/transform_output_iterator.hpp) to thrust.

While `thrust::transform_iterator` acts as a "source" by applying a transformation on an `Iterator`, `thrust::transform_output_iterator` acts as "sink".
It allows  to apply a transform operation on a wrapped `OutputIterator` before actually writing to this `OutputIterator`. This can be used to post-process results from a previous thrust call.