### PR TITLE
provide NVVMIR_LIBRARY_DIR environment variable to nvcc

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -440,6 +440,10 @@ elif master_env['PLATFORM'] == 'win32':
   master_env['ENV']['TBBROOT'] = os.environ['TBBROOT']
   master_env['ENV']['PATH'] += ';' + tbb_installation(master_env)[0]
 
+# if the environment variable NVVMIR_LIBRARY_DIR is set, provide it to nvcc to prevent the following error:
+# "nvcc fatal : Path to libdevice library not specified"
+if 'NVVMIR_LIBRARY_DIR' in os.environ:
+  master_env['ENV']['NVVMIR_LIBRARY_DIR'] = os.environ['NVVMIR_LIBRARY_DIR']
 
 # get the list of requested backends
 host_backends = master_env.subst('$host_backend').split()


### PR DESCRIPTION
If a system does not use a `nvcc.profile` file but sets `NVVMIR_LIBRARY_DIR` as an environment variable instead, building thrust tests fails with:

```
 nvcc fatal : Path to libdevice library not specified
```

This patch provides `NVVMIR_LIBRARY_DIR` to `nvcc` if this environment variable is set.
