### PR TITLE
Add fake #includes to fix SCons dependencies in thrust/system/detail/…

### DIFF
--- a/thrust/system/detail/adl/adjacent_difference.h
+++ b/thrust/system/detail/adl/adjacent_difference.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/adjacent_difference.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/adjacent_difference.h>
+#include <thrust/system/cuda/detail/adjacent_difference.h>
+#include <thrust/system/omp/detail/adjacent_difference.h>
+#include <thrust/system/tbb/detail/adjacent_difference.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_ADJACENT_DIFFERENCE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/adjacent_difference.h>
 #include __THRUST_HOST_SYSTEM_ADJACENT_DIFFERENCE_HEADER
 #undef __THRUST_HOST_SYSTEM_ADJACENT_DIFFERENCE_HEADER

--- a/thrust/system/detail/adl/assign_value.h
+++ b/thrust/system/detail/adl/assign_value.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/assign_value.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/assign_value.h>
+#include <thrust/system/cuda/detail/assign_value.h>
+#include <thrust/system/omp/detail/assign_value.h>
+#include <thrust/system/tbb/detail/assign_value.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_ASSIGN_VALUE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/assign_value.h>
 #include __THRUST_HOST_SYSTEM_ASSIGN_VALUE_HEADER
 #undef __THRUST_HOST_SYSTEM_ASSIGN_VALUE_HEADER

--- a/thrust/system/detail/adl/binary_search.h
+++ b/thrust/system/detail/adl/binary_search.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/binary_search.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/binary_search.h>
+#include <thrust/system/cuda/detail/binary_search.h>
+#include <thrust/system/omp/detail/binary_search.h>
+#include <thrust/system/tbb/detail/binary_search.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_BINARY_SEARCH_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/binary_search.h>
 #include __THRUST_HOST_SYSTEM_BINARY_SEARCH_HEADER
 #undef __THRUST_HOST_SYSTEM_BINARY_SEARCH_HEADER

--- a/thrust/system/detail/adl/copy.h
+++ b/thrust/system/detail/adl/copy.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/copy.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/copy.h>
+#include <thrust/system/cuda/detail/copy.h>
+#include <thrust/system/omp/detail/copy.h>
+#include <thrust/system/tbb/detail/copy.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_COPY_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/copy.h>
 #include __THRUST_HOST_SYSTEM_COPY_HEADER
 #undef __THRUST_HOST_SYSTEM_COPY_HEADER

--- a/thrust/system/detail/adl/copy_if.h
+++ b/thrust/system/detail/adl/copy_if.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/copy_if.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/copy_if.h>
+#include <thrust/system/cuda/detail/copy_if.h>
+#include <thrust/system/omp/detail/copy_if.h>
+#include <thrust/system/tbb/detail/copy_if.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_BINARY_SEARCH_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/copy_if.h>
 #include __THRUST_HOST_SYSTEM_BINARY_SEARCH_HEADER
 #undef __THRUST_HOST_SYSTEM_BINARY_SEARCH_HEADER

--- a/thrust/system/detail/adl/count.h
+++ b/thrust/system/detail/adl/count.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/count.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/count.h>
+#include <thrust/system/cuda/detail/count.h>
+#include <thrust/system/omp/detail/count.h>
+#include <thrust/system/tbb/detail/count.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_COUNT_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/count.h>
 #include __THRUST_HOST_SYSTEM_COUNT_HEADER
 #undef __THRUST_HOST_SYSTEM_COUNT_HEADER

--- a/thrust/system/detail/adl/equal.h
+++ b/thrust/system/detail/adl/equal.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/equal.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/equal.h>
+#include <thrust/system/cuda/detail/equal.h>
+#include <thrust/system/omp/detail/equal.h>
+#include <thrust/system/tbb/detail/equal.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_EQUAL_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/equal.h>
 #include __THRUST_HOST_SYSTEM_EQUAL_HEADER
 #undef __THRUST_HOST_SYSTEM_EQUAL_HEADER

--- a/thrust/system/detail/adl/extrema.h
+++ b/thrust/system/detail/adl/extrema.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/extrema.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/extrema.h>
+#include <thrust/system/cuda/detail/extrema.h>
+#include <thrust/system/omp/detail/extrema.h>
+#include <thrust/system/tbb/detail/extrema.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_EXTREMA_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/extrema.h>
 #include __THRUST_HOST_SYSTEM_EXTREMA_HEADER
 #undef __THRUST_HOST_SYSTEM_EXTREMA_HEADER

--- a/thrust/system/detail/adl/fill.h
+++ b/thrust/system/detail/adl/fill.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/fill.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/fill.h>
+#include <thrust/system/cuda/detail/fill.h>
+#include <thrust/system/omp/detail/fill.h>
+#include <thrust/system/tbb/detail/fill.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_FILL_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/fill.h>
 #include __THRUST_HOST_SYSTEM_FILL_HEADER
 #undef __THRUST_HOST_SYSTEM_FILL_HEADER

--- a/thrust/system/detail/adl/find.h
+++ b/thrust/system/detail/adl/find.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/find.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/find.h>
+#include <thrust/system/cuda/detail/find.h>
+#include <thrust/system/omp/detail/find.h>
+#include <thrust/system/tbb/detail/find.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_FIND_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/find.h>
 #include __THRUST_HOST_SYSTEM_FIND_HEADER
 #undef __THRUST_HOST_SYSTEM_FIND_HEADER

--- a/thrust/system/detail/adl/for_each.h
+++ b/thrust/system/detail/adl/for_each.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/for_each.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/for_each.h>
+#include <thrust/system/cuda/detail/for_each.h>
+#include <thrust/system/omp/detail/for_each.h>
+#include <thrust/system/tbb/detail/for_each.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_FOR_EACH_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/for_each.h>
 #include __THRUST_HOST_SYSTEM_FOR_EACH_HEADER
 #undef __THRUST_HOST_SYSTEM_FOR_EACH_HEADER

--- a/thrust/system/detail/adl/gather.h
+++ b/thrust/system/detail/adl/gather.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/gather.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/gather.h>
+#include <thrust/system/cuda/detail/gather.h>
+#include <thrust/system/omp/detail/gather.h>
+#include <thrust/system/tbb/detail/gather.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_GATHER_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/gather.h>
 #include __THRUST_HOST_SYSTEM_GATHER_HEADER
 #undef __THRUST_HOST_SYSTEM_GATHER_HEADER

--- a/thrust/system/detail/adl/generate.h
+++ b/thrust/system/detail/adl/generate.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/generate.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/generate.h>
+#include <thrust/system/cuda/detail/generate.h>
+#include <thrust/system/omp/detail/generate.h>
+#include <thrust/system/tbb/detail/generate.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_GENERATE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/generate.h>
 #include __THRUST_HOST_SYSTEM_GENERATE_HEADER
 #undef __THRUST_HOST_SYSTEM_GENERATE_HEADER

--- a/thrust/system/detail/adl/get_value.h
+++ b/thrust/system/detail/adl/get_value.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/get_value.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/get_value.h>
+#include <thrust/system/cuda/detail/get_value.h>
+#include <thrust/system/omp/detail/get_value.h>
+#include <thrust/system/tbb/detail/get_value.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_GET_VALUE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/get_value.h>
 #include __THRUST_HOST_SYSTEM_GET_VALUE_HEADER
 #undef __THRUST_HOST_SYSTEM_GET_VALUE_HEADER

--- a/thrust/system/detail/adl/inner_product.h
+++ b/thrust/system/detail/adl/inner_product.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/inner_product.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/inner_product.h>
+#include <thrust/system/cuda/detail/inner_product.h>
+#include <thrust/system/omp/detail/inner_product.h>
+#include <thrust/system/tbb/detail/inner_product.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_INNER_PRODUCT_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/inner_product.h>
 #include __THRUST_HOST_SYSTEM_INNER_PRODUCT_HEADER
 #undef __THRUST_HOST_SYSTEM_INNER_PRODUCT_HEADER

--- a/thrust/system/detail/adl/iter_swap.h
+++ b/thrust/system/detail/adl/iter_swap.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/iter_swap.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/iter_swap.h>
+#include <thrust/system/cuda/detail/iter_swap.h>
+#include <thrust/system/omp/detail/iter_swap.h>
+#include <thrust/system/tbb/detail/iter_swap.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_ITER_SWAP_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/iter_swap.h>
 #include __THRUST_HOST_SYSTEM_ITER_SWAP_HEADER
 #undef __THRUST_HOST_SYSTEM_ITER_SWAP_HEADER

--- a/thrust/system/detail/adl/logical.h
+++ b/thrust/system/detail/adl/logical.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/logical.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/logical.h>
+#include <thrust/system/cuda/detail/logical.h>
+#include <thrust/system/omp/detail/logical.h>
+#include <thrust/system/tbb/detail/logical.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_LOGICAL_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/logical.h>
 #include __THRUST_HOST_SYSTEM_LOGICAL_HEADER
 #undef __THRUST_HOST_SYSTEM_LOGICAL_HEADER

--- a/thrust/system/detail/adl/malloc_and_free.h
+++ b/thrust/system/detail/adl/malloc_and_free.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/malloc_and_free.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/malloc_and_free.h>
+#include <thrust/system/cuda/detail/malloc_and_free.h>
+#include <thrust/system/omp/detail/malloc_and_free.h>
+#include <thrust/system/tbb/detail/malloc_and_free.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_MALLOC_AND_FREE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/malloc_and_free.h>
 #include __THRUST_HOST_SYSTEM_MALLOC_AND_FREE_HEADER
 #undef __THRUST_HOST_SYSTEM_MALLOC_AND_FREE_HEADER

--- a/thrust/system/detail/adl/merge.h
+++ b/thrust/system/detail/adl/merge.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/merge.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/merge.h>
+#include <thrust/system/cuda/detail/merge.h>
+#include <thrust/system/omp/detail/merge.h>
+#include <thrust/system/tbb/detail/merge.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_MERGE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/merge.h>
 #include __THRUST_HOST_SYSTEM_MERGE_HEADER
 #undef __THRUST_HOST_SYSTEM_MERGE_HEADER

--- a/thrust/system/detail/adl/mismatch.h
+++ b/thrust/system/detail/adl/mismatch.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/mismatch.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/mismatch.h>
+#include <thrust/system/cuda/detail/mismatch.h>
+#include <thrust/system/omp/detail/mismatch.h>
+#include <thrust/system/tbb/detail/mismatch.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_MISMATCH_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/mismatch.h>
 #include __THRUST_HOST_SYSTEM_MISMATCH_HEADER
 #undef __THRUST_HOST_SYSTEM_MISMATCH_HEADER

--- a/thrust/system/detail/adl/partition.h
+++ b/thrust/system/detail/adl/partition.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/partition.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/partition.h>
+#include <thrust/system/cuda/detail/partition.h>
+#include <thrust/system/omp/detail/partition.h>
+#include <thrust/system/tbb/detail/partition.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_PARTITION_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/partition.h>
 #include __THRUST_HOST_SYSTEM_PARTITION_HEADER
 #undef __THRUST_HOST_SYSTEM_PARTITION_HEADER

--- a/thrust/system/detail/adl/reduce.h
+++ b/thrust/system/detail/adl/reduce.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/reduce.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/reduce.h>
+#include <thrust/system/cuda/detail/reduce.h>
+#include <thrust/system/omp/detail/reduce.h>
+#include <thrust/system/tbb/detail/reduce.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_REDUCE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/reduce.h>
 #include __THRUST_HOST_SYSTEM_REDUCE_HEADER
 #undef __THRUST_HOST_SYSTEM_REDUCE_HEADER

--- a/thrust/system/detail/adl/reduce_by_key.h
+++ b/thrust/system/detail/adl/reduce_by_key.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/reduce_by_key.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/reduce_by_key.h>
+#include <thrust/system/cuda/detail/reduce_by_key.h>
+#include <thrust/system/omp/detail/reduce_by_key.h>
+#include <thrust/system/tbb/detail/reduce_by_key.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_REDUCE_BY_KEY_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/reduce_by_key.h>
 #include __THRUST_HOST_SYSTEM_REDUCE_BY_KEY_HEADER
 #undef __THRUST_HOST_SYSTEM_REDUCE_BY_KEY_HEADER

--- a/thrust/system/detail/adl/remove.h
+++ b/thrust/system/detail/adl/remove.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/remove.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/remove.h>
+#include <thrust/system/cuda/detail/remove.h>
+#include <thrust/system/omp/detail/remove.h>
+#include <thrust/system/tbb/detail/remove.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_REMOVE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/remove.h>
 #include __THRUST_HOST_SYSTEM_REMOVE_HEADER
 #undef __THRUST_HOST_SYSTEM_REMOVE_HEADER

--- a/thrust/system/detail/adl/replace.h
+++ b/thrust/system/detail/adl/replace.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/replace.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/replace.h>
+#include <thrust/system/cuda/detail/replace.h>
+#include <thrust/system/omp/detail/replace.h>
+#include <thrust/system/tbb/detail/replace.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_REPLACE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/replace.h>
 #include __THRUST_HOST_SYSTEM_REPLACE_HEADER
 #undef __THRUST_HOST_SYSTEM_REPLACE_HEADER

--- a/thrust/system/detail/adl/reverse.h
+++ b/thrust/system/detail/adl/reverse.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/reverse.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/reverse.h>
+#include <thrust/system/cuda/detail/reverse.h>
+#include <thrust/system/omp/detail/reverse.h>
+#include <thrust/system/tbb/detail/reverse.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_REVERSE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/reverse.h>
 #include __THRUST_HOST_SYSTEM_REVERSE_HEADER
 #undef __THRUST_HOST_SYSTEM_REVERSE_HEADER

--- a/thrust/system/detail/adl/scan.h
+++ b/thrust/system/detail/adl/scan.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/scan.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/scan.h>
+#include <thrust/system/cuda/detail/scan.h>
+#include <thrust/system/omp/detail/scan.h>
+#include <thrust/system/tbb/detail/scan.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_SCAN_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/scan.h>
 #include __THRUST_HOST_SYSTEM_SCAN_HEADER
 #undef __THRUST_HOST_SYSTEM_SCAN_HEADER

--- a/thrust/system/detail/adl/scan_by_key.h
+++ b/thrust/system/detail/adl/scan_by_key.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/scan_by_key.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/scan_by_key.h>
+#include <thrust/system/cuda/detail/scan_by_key.h>
+#include <thrust/system/omp/detail/scan_by_key.h>
+#include <thrust/system/tbb/detail/scan_by_key.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_SCAN_BY_KEY_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/scan_by_key.h>
 #include __THRUST_HOST_SYSTEM_SCAN_BY_KEY_HEADER
 #undef __THRUST_HOST_SYSTEM_SCAN_BY_KEY_HEADER

--- a/thrust/system/detail/adl/scatter.h
+++ b/thrust/system/detail/adl/scatter.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/scatter.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/scatter.h>
+#include <thrust/system/cuda/detail/scatter.h>
+#include <thrust/system/omp/detail/scatter.h>
+#include <thrust/system/tbb/detail/scatter.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_SCATTER_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/scatter.h>
 #include __THRUST_HOST_SYSTEM_SCATTER_HEADER
 #undef __THRUST_HOST_SYSTEM_SCATTER_HEADER

--- a/thrust/system/detail/adl/sequence.h
+++ b/thrust/system/detail/adl/sequence.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/sequence.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/sequence.h>
+#include <thrust/system/cuda/detail/sequence.h>
+#include <thrust/system/omp/detail/sequence.h>
+#include <thrust/system/tbb/detail/sequence.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_SEQUENCE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/sequence.h>
 #include __THRUST_HOST_SYSTEM_SEQUENCE_HEADER
 #undef __THRUST_HOST_SYSTEM_SEQUENCE_HEADER

--- a/thrust/system/detail/adl/set_operations.h
+++ b/thrust/system/detail/adl/set_operations.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/set_operations.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/set_operations.h>
+#include <thrust/system/cuda/detail/set_operations.h>
+#include <thrust/system/omp/detail/set_operations.h>
+#include <thrust/system/tbb/detail/set_operations.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_SET_OPERATIONS_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/set_operations.h>
 #include __THRUST_HOST_SYSTEM_SET_OPERATIONS_HEADER
 #undef __THRUST_HOST_SYSTEM_SET_OPERATIONS_HEADER

--- a/thrust/system/detail/adl/sort.h
+++ b/thrust/system/detail/adl/sort.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/sort.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/sort.h>
+#include <thrust/system/cuda/detail/sort.h>
+#include <thrust/system/omp/detail/sort.h>
+#include <thrust/system/tbb/detail/sort.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_SORT_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/sort.h>
 #include __THRUST_HOST_SYSTEM_SORT_HEADER
 #undef __THRUST_HOST_SYSTEM_SORT_HEADER

--- a/thrust/system/detail/adl/swap_ranges.h
+++ b/thrust/system/detail/adl/swap_ranges.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/swap_ranges.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/swap_ranges.h>
+#include <thrust/system/cuda/detail/swap_ranges.h>
+#include <thrust/system/omp/detail/swap_ranges.h>
+#include <thrust/system/tbb/detail/swap_ranges.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_SWAP_RANGES_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/swap_ranges.h>
 #include __THRUST_HOST_SYSTEM_SWAP_RANGES_HEADER
 #undef __THRUST_HOST_SYSTEM_SWAP_RANGES_HEADER

--- a/thrust/system/detail/adl/tabulate.h
+++ b/thrust/system/detail/adl/tabulate.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/tabulate.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/tabulate.h>
+#include <thrust/system/cuda/detail/tabulate.h>
+#include <thrust/system/omp/detail/tabulate.h>
+#include <thrust/system/tbb/detail/tabulate.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_TABULATE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/tabulate.h>
 #include __THRUST_HOST_SYSTEM_TABULATE_HEADER
 #undef __THRUST_HOST_SYSTEM_TABULATE_HEADER

--- a/thrust/system/detail/adl/temporary_buffer.h
+++ b/thrust/system/detail/adl/temporary_buffer.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/temporary_buffer.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/temporary_buffer.h>
+#include <thrust/system/cuda/detail/temporary_buffer.h>
+#include <thrust/system/omp/detail/temporary_buffer.h>
+#include <thrust/system/tbb/detail/temporary_buffer.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_TEMPORARY_BUFFER_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/temporary_buffer.h>
 #include __THRUST_HOST_SYSTEM_TEMPORARY_BUFFER_HEADER
 #undef __THRUST_HOST_SYSTEM_TEMPORARY_BUFFER_HEADER

--- a/thrust/system/detail/adl/transform.h
+++ b/thrust/system/detail/adl/transform.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/transform.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/transform.h>
+#include <thrust/system/cuda/detail/transform.h>
+#include <thrust/system/omp/detail/transform.h>
+#include <thrust/system/tbb/detail/transform.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_TRANSFORM_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/transform.h>
 #include __THRUST_HOST_SYSTEM_TRANSFORM_HEADER
 #undef __THRUST_HOST_SYSTEM_TRANSFORM_HEADER

--- a/thrust/system/detail/adl/transform_reduce.h
+++ b/thrust/system/detail/adl/transform_reduce.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/transform_reduce.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/transform_reduce.h>
+#include <thrust/system/cuda/detail/transform_reduce.h>
+#include <thrust/system/omp/detail/transform_reduce.h>
+#include <thrust/system/tbb/detail/transform_reduce.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_TRANSFORM_REDUCE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/transform_reduce.h>
 #include __THRUST_HOST_SYSTEM_TRANSFORM_REDUCE_HEADER
 #undef __THRUST_HOST_SYSTEM_TRANSFORM_REDUCE_HEADER

--- a/thrust/system/detail/adl/transform_scan.h
+++ b/thrust/system/detail/adl/transform_scan.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/transform_scan.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/transform_scan.h>
+#include <thrust/system/cuda/detail/transform_scan.h>
+#include <thrust/system/omp/detail/transform_scan.h>
+#include <thrust/system/tbb/detail/transform_scan.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_TRANSFORM_SCAN_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/transform_scan.h>
 #include __THRUST_HOST_SYSTEM_TRANSFORM_SCAN_HEADER
 #undef __THRUST_HOST_SYSTEM_TRANSFORM_SCAN_HEADER

--- a/thrust/system/detail/adl/uninitialized_copy.h
+++ b/thrust/system/detail/adl/uninitialized_copy.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/uninitialized_copy.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/uninitialized_copy.h>
+#include <thrust/system/cuda/detail/uninitialized_copy.h>
+#include <thrust/system/omp/detail/uninitialized_copy.h>
+#include <thrust/system/tbb/detail/uninitialized_copy.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_UNINITIALIZED_COPY_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/uninitialized_copy.h>
 #include __THRUST_HOST_SYSTEM_UNINITIALIZED_COPY_HEADER
 #undef __THRUST_HOST_SYSTEM_UNINITIALIZED_COPY_HEADER

--- a/thrust/system/detail/adl/uninitialized_fill.h
+++ b/thrust/system/detail/adl/uninitialized_fill.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/uninitialized_fill.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/uninitialized_fill.h>
+#include <thrust/system/cuda/detail/uninitialized_fill.h>
+#include <thrust/system/omp/detail/uninitialized_fill.h>
+#include <thrust/system/tbb/detail/uninitialized_fill.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_UNINITIALIZED_FILL_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/uninitialized_fill.h>
 #include __THRUST_HOST_SYSTEM_UNINITIALIZED_FILL_HEADER
 #undef __THRUST_HOST_SYSTEM_UNINITIALIZED_FILL_HEADER

--- a/thrust/system/detail/adl/unique.h
+++ b/thrust/system/detail/adl/unique.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/unique.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/unique.h>
+#include <thrust/system/cuda/detail/unique.h>
+#include <thrust/system/omp/detail/unique.h>
+#include <thrust/system/tbb/detail/unique.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_UNIQUE_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/unique.h>
 #include __THRUST_HOST_SYSTEM_UNIQUE_HEADER
 #undef __THRUST_HOST_SYSTEM_UNIQUE_HEADER

--- a/thrust/system/detail/adl/unique_by_key.h
+++ b/thrust/system/detail/adl/unique_by_key.h
@@ -24,6 +24,16 @@
 
 #include <thrust/system/detail/sequential/unique_by_key.h>
 
+// SCons can't see through the #defines below to figure out what this header
+// includes, so we fake it out by specifying all possible files we might end up
+// including inside an #if 0.
+#if 0
+#include <thrust/system/cpp/detail/unique_by_key.h>
+#include <thrust/system/cuda/detail/unique_by_key.h>
+#include <thrust/system/omp/detail/unique_by_key.h>
+#include <thrust/system/tbb/detail/unique_by_key.h>
+#endif
+
 #define __THRUST_HOST_SYSTEM_UNIQUE_BY_KEY_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/unique_by_key.h>
 #include __THRUST_HOST_SYSTEM_UNIQUE_BY_KEY_HEADER
 #undef __THRUST_HOST_SYSTEM_UNIQUE_BY_KEY_HEADER


### PR DESCRIPTION
…adl headers.

SCons figures out dependencies by textually scanning header files.  This
means that it misses dependencies of the form e.g.

    #define foo bar.h
    #include foo

Unfortunately this is exactly what we do in the adl headers.

In the case of the adl headers, we're using #defines to switch between a
few possible header files, so it's fine if SCons simply generates a
dependency on all of the files that we might depend on.  To accomplish
this, we add #includes for all files that we might include, but stick
those #includes inside an #if 0.  This way the includes are visible only
to SCons.