### PR TITLE
Make type traits work with clang.

### DIFF
--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -122,7 +122,8 @@ template<typename T> struct is_pod
    : public integral_constant<
        bool,
        is_void<T>::value || is_pointer<T>::value || is_arithmetic<T>::value
-#if THRUST_HOST_COMPILER   == THRUST_HOST_COMPILER_MSVC
+#if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
+    THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
 // use intrinsic type traits
        || __is_pod(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
@@ -139,7 +140,8 @@ template<typename T> struct has_trivial_constructor
   : public integral_constant<
       bool,
       is_pod<T>::value
-#if THRUST_HOST_COMPILER   == THRUST_HOST_COMPILER_MSVC
+#if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
+    THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
       || __has_trivial_constructor(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
@@ -154,7 +156,8 @@ template<typename T> struct has_trivial_copy_constructor
   : public integral_constant<
       bool,
       is_pod<T>::value
-#if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
+#if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
+    THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
       || __has_trivial_copy(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3

--- a/thrust/detail/type_traits/has_trivial_assign.h
+++ b/thrust/detail/type_traits/has_trivial_assign.h
@@ -42,6 +42,8 @@ template<typename T> struct has_trivial_assign
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
       || __has_trivial_assign(T)
 #endif // GCC VERSION
+#elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
+      || __has_trivial_assign(T)
 #endif // THRUST_HOST_COMPILER
     >
 {};


### PR DESCRIPTION
See http://libcxx.llvm.org/type_traits_design.html for the list of intrinsics supported by clang.