### PR TITLE
Pull isinf/isnan/signbit and isfinite from std namespace

### DIFF
--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -100,7 +100,7 @@ __host__ __device__ inline int isfinite(double x){
 
 #else
 
-#  ifdef __CUDACC__
+#  if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
 
 // sometimes the CUDA toolkit provides these these names as macros,
 // sometimes functions in the global scope


### PR DESCRIPTION
... if we're compiling with clang which (as of r258880) provides device-side wrappers for them.

This is needed to provide clang with access to both host and device-side variants of those functions.
Global scope will not have host-side variants available if they were implemented as preprocessor macros.