### PR TITLE
Fix osx compilation

### DIFF
--- a/testing/unittest/assertions.h
+++ b/testing/unittest/assertions.h
@@ -29,8 +29,13 @@ namespace unittest
 
 static size_t MAX_OUTPUT_LINES = 10;
 
+#ifndef __APPLE_CC__
 static double DEFAULT_RELATIVE_TOL = 1e-4;
 static double DEFAULT_ABSOLUTE_TOL = 1e-4;
+#else
+#define DEFAULT_RELATIVE_TOL (1e-4)
+#define DEFAULT_ABSOLUTE_TOL (1e-4)
+#endif
 
 template<typename T>
   struct value_type

--- a/testing/unittest/assertions.h
+++ b/testing/unittest/assertions.h
@@ -29,13 +29,8 @@ namespace unittest
 
 static size_t MAX_OUTPUT_LINES = 10;
 
-#ifndef __APPLE_CC__
 static double DEFAULT_RELATIVE_TOL = 1e-4;
 static double DEFAULT_ABSOLUTE_TOL = 1e-4;
-#else
-#define DEFAULT_RELATIVE_TOL (1e-4)
-#define DEFAULT_ABSOLUTE_TOL (1e-4)
-#endif
 
 template<typename T>
   struct value_type

--- a/thrust/detail/config/exec_check_disable.h
+++ b/thrust/detail/config/exec_check_disable.h
@@ -22,7 +22,7 @@
 
 #include <thrust/detail/config.h>
 
-#if defined(__CUDACC__) && !defined(__clang__)
+#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
 
 #define __thrust_exec_check_disable__ \
 #pragma hd_warning_disable \

--- a/thrust/detail/config/exec_check_disable.h
+++ b/thrust/detail/config/exec_check_disable.h
@@ -22,7 +22,7 @@
 
 #include <thrust/detail/config.h>
 
-#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
+#if defined(__CUDACC__) && !defined(__clang__)
 
 #define __thrust_exec_check_disable__ \
 #pragma hd_warning_disable \

--- a/thrust/system/cuda/detail/bulk/detail/config.hpp
+++ b/thrust/system/cuda/detail/bulk/detail/config.hpp
@@ -24,7 +24,7 @@
 #define BULK_NAMESPACE_SUFFIX
 #endif
 
-#if defined(__CUDACC__) && !defined(__clang__)
+#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
 #  ifndef __bulk_exec_check_disable__
 #    define __bulk_exec_check_disable__ \
 #    pragma nv_exec_check_disable \

--- a/thrust/system/cuda/detail/bulk/detail/config.hpp
+++ b/thrust/system/cuda/detail/bulk/detail/config.hpp
@@ -24,7 +24,7 @@
 #define BULK_NAMESPACE_SUFFIX
 #endif
 
-#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
+#if defined(__CUDACC__) && !defined(__clang__)
 #  ifndef __bulk_exec_check_disable__
 #    define __bulk_exec_check_disable__ \
 #    pragma nv_exec_check_disable \


### PR DESCRIPTION
Added defined(__CUDA__) guard to enable `#pragma` when host compiler is clang.