### PR TITLE
Tweak condition in on_chip_cast used for detecting specifically nvcc …

### DIFF
--- a/thrust/system/cuda/detail/bulk/malloc.hpp
+++ b/thrust/system/cuda/detail/bulk/malloc.hpp
@@ -38,7 +38,7 @@ inline __device__ bool is_on_chip(void *ptr)
 template<typename T>
 inline __device__ T *on_chip_cast(T *ptr)
 {
-#if defined(__CUDA__) && defined(__NVCC__) && !defined(__clang__)
+#if defined(__NVCC__) && !(defined(__CUDA__) && defined(__clang__))
   // The below is UB in three ways:
   //  * s_begin is not defined anywhere, so using it is an ODR violation.
   //  * Pointer arithmetic is not defined to wrap, so (ptr - s_begin) + s_begin


### PR DESCRIPTION
…(not clang).

This was added in b59890f, but the condition was wrong -- nvcc doesn't
declare __CUDA__.