### PR TITLE
Add additional __host__ __device__ attributes.

### DIFF
--- a/thrust/detail/adjacent_difference.inl
+++ b/thrust/detail/adjacent_difference.inl
@@ -30,6 +30,7 @@ namespace thrust
 
 __thrust_exec_check_disable__ 
 template <typename DerivedPolicy, typename InputIterator, typename OutputIterator>
+__host__ __device__
 OutputIterator adjacent_difference(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
                                    InputIterator first, InputIterator last, 
                                    OutputIterator result)
@@ -42,6 +43,7 @@ OutputIterator adjacent_difference(const thrust::detail::execution_policy_base<D
 
 __thrust_exec_check_disable__ 
 template <typename DerivedPolicy, typename InputIterator, typename OutputIterator, typename BinaryFunction>
+__host__ __device__
 OutputIterator adjacent_difference(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
                                    InputIterator first, InputIterator last, 
                                    OutputIterator result,

--- a/thrust/system/cuda/detail/memory.inl
+++ b/thrust/system/cuda/detail/memory.inl
@@ -44,21 +44,15 @@ namespace system
 namespace cuda
 {
 
-
-template<typename T>
-  template<typename OtherT>
-    reference<T> &
-      reference<T>
-        ::operator=(const reference<OtherT> &other)
-{
+template <typename T>
+template <typename OtherT>
+__host__ __device__ reference<T> &reference<T>::operator=(
+    const reference<OtherT> &other) {
   return super_t::operator=(other);
 } // end reference::operator=()
 
-template<typename T>
-  reference<T> &
-    reference<T>
-      ::operator=(const value_type &x)
-{
+template <typename T>
+__host__ __device__ reference<T> &reference<T>::operator=(const value_type &x) {
   return super_t::operator=(x);
 } // end reference::operator=()
 

--- a/thrust/system/detail/generic/unique_by_key.inl
+++ b/thrust/system/detail/generic/unique_by_key.inl
@@ -41,11 +41,12 @@ namespace generic
 template<typename ExecutionPolicy,
          typename ForwardIterator1,
          typename ForwardIterator2>
-  thrust::pair<ForwardIterator1,ForwardIterator2>
-    unique_by_key(thrust::execution_policy<ExecutionPolicy> &exec,
-                  ForwardIterator1 keys_first, 
-                  ForwardIterator1 keys_last,
-                  ForwardIterator2 values_first)
+__host__ __device__
+thrust::pair<ForwardIterator1,ForwardIterator2>
+unique_by_key(thrust::execution_policy<ExecutionPolicy> &exec,
+              ForwardIterator1 keys_first,
+              ForwardIterator1 keys_last,
+              ForwardIterator2 values_first)
 {
   typedef typename thrust::iterator_traits<ForwardIterator1>::value_type KeyType;
   return thrust::unique_by_key(exec, keys_first, keys_last, values_first, thrust::equal_to<KeyType>());
@@ -56,21 +57,22 @@ template<typename ExecutionPolicy,
          typename ForwardIterator1,
          typename ForwardIterator2,
          typename BinaryPredicate>
-  thrust::pair<ForwardIterator1,ForwardIterator2>
-    unique_by_key(thrust::execution_policy<ExecutionPolicy> &exec,
-                  ForwardIterator1 keys_first, 
-                  ForwardIterator1 keys_last,
-                  ForwardIterator2 values_first,
-                  BinaryPredicate binary_pred)
+__host__ __device__
+thrust::pair<ForwardIterator1,ForwardIterator2>
+unique_by_key(thrust::execution_policy<ExecutionPolicy> &exec,
+              ForwardIterator1 keys_first,
+              ForwardIterator1 keys_last,
+              ForwardIterator2 values_first,
+              BinaryPredicate binary_pred)
 {
   typedef typename thrust::iterator_traits<ForwardIterator1>::value_type InputType1;
   typedef typename thrust::iterator_traits<ForwardIterator2>::value_type InputType2;
-  
+
   ForwardIterator2 values_last = values_first + (keys_last - keys_first);
-  
+
   thrust::detail::temporary_array<InputType1,ExecutionPolicy> keys(exec, keys_first, keys_last);
   thrust::detail::temporary_array<InputType2,ExecutionPolicy> vals(exec, values_first, values_last);
-  
+
   return thrust::unique_by_key_copy(exec, keys.begin(), keys.end(), vals.begin(), keys_first, values_first, binary_pred);
 } // end unique_by_key()
 
@@ -80,13 +82,14 @@ template<typename ExecutionPolicy,
          typename InputIterator2,
          typename OutputIterator1,
          typename OutputIterator2>
-  thrust::pair<OutputIterator1,OutputIterator2>
-    unique_by_key_copy(thrust::execution_policy<ExecutionPolicy> &exec,
-                       InputIterator1 keys_first, 
-                       InputIterator1 keys_last,
-                       InputIterator2 values_first,
-                       OutputIterator1 keys_output,
-                       OutputIterator2 values_output)
+__host__ __device__
+thrust::pair<OutputIterator1,OutputIterator2>
+unique_by_key_copy(thrust::execution_policy<ExecutionPolicy> &exec,
+                   InputIterator1 keys_first,
+                   InputIterator1 keys_last,
+                   InputIterator2 values_first,
+                   OutputIterator1 keys_output,
+                   OutputIterator2 values_output)
 {
   typedef typename thrust::iterator_traits<InputIterator1>::value_type KeyType;
   return thrust::unique_by_key_copy(exec, keys_first, keys_last, values_first, keys_output, values_output, thrust::equal_to<KeyType>());
@@ -99,17 +102,18 @@ template<typename ExecutionPolicy,
          typename OutputIterator1,
          typename OutputIterator2,
          typename BinaryPredicate>
-  thrust::pair<OutputIterator1,OutputIterator2>
-    unique_by_key_copy(thrust::execution_policy<ExecutionPolicy> &exec,
-                       InputIterator1 keys_first, 
-                       InputIterator1 keys_last,
-                       InputIterator2 values_first,
-                       OutputIterator1 keys_output,
-                       OutputIterator2 values_output,
-                       BinaryPredicate binary_pred)
+__host__ __device__
+thrust::pair<OutputIterator1,OutputIterator2>
+unique_by_key_copy(thrust::execution_policy<ExecutionPolicy> &exec,
+                   InputIterator1 keys_first,
+                   InputIterator1 keys_last,
+                   InputIterator2 values_first,
+                   OutputIterator1 keys_output,
+                   OutputIterator2 values_output,
+                   BinaryPredicate binary_pred)
 {
   typedef typename thrust::iterator_traits<InputIterator1>::difference_type difference_type;
-  
+
   difference_type n = thrust::distance(keys_first, keys_last);
 
   thrust::detail::head_flags<InputIterator1, BinaryPredicate> stencil(keys_first, keys_last, binary_pred);
@@ -122,9 +126,9 @@ template<typename ExecutionPolicy,
                     stencil.begin(),
                     thrust::make_zip_iterator(thrust::make_tuple(keys_output, values_output)),
                     _1);
-  
+
   difference_type output_size = result - thrust::make_zip_iterator(thrust::make_tuple(keys_output, values_output));
-                                  
+
   return thrust::make_pair(keys_output + output_size, values_output + output_size);
 } // end unique_by_key_copy()
 


### PR DESCRIPTION
clang is stricter about requiring defs' and decls' attributes to match
than nvcc.  Currently clang doesn't care if you have a `__host__`
`__device__` decl and an unattributed def, but that is likely to change
soon, as a side-effect of supporting --relaxed-constexpr.

This patch also cleans up some whitespace.