### PR TITLE
Taught thrust::complex to provide an empty constructor.

### DIFF
--- a/thrust/complex.h
+++ b/thrust/complex.h
@@ -67,13 +67,19 @@ public:
 
   /* --- Constructors --- */
 
+  /*! Construct an uninitialized complex number.
+   *
+   */
+  inline __host__ __device__
+  complex();
+
   /*! Construct a complex number from its real and imaginary parts.
    *
    *  \param re The real part of the number.
    *  \param im The imaginary part of the number.
    */
   inline __host__ __device__      
-  complex(const T & re = T(), const T& im = T());
+  complex(const T & re, const T& im = T());
 
   /*! This copy constructor copies from a \p complex with a type that
    *  is convertible to this \p complex \c value_type.

--- a/thrust/detail/complex/complex.inl
+++ b/thrust/detail/complex/complex.inl
@@ -24,6 +24,14 @@ namespace thrust
 
 template <typename T>
 inline __host__ __device__  complex<T>
+::complex()
+{
+  // Intentionally empty. Providing an empty constructor allows
+  // for complex<T> variables with shared, device or global scope.
+}
+
+template <typename T>
+inline __host__ __device__  complex<T>
 ::complex(const T & re, const T& im)
 {
   real(re);


### PR DESCRIPTION
This patch allows thrust::complex objects to be created with **shared**, **device** or **global** scope.

This change fixes a compiler error we encountered (dynamic initialization not supported) when trying to use thrust::complex in an OptiX ray payload struct.
