### PR TITLE
Dereference iterator via get_value(derived_cast(exec),iterator)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,12 +6,11 @@ Summary
     Small bug fixes
 
 New Examples
-  range_view demonstrates use of a view: a non-owning wrapper for an iterator range with a container-like interface
-
-
+    range_view demonstrates use of a view: a non-owning wrapper for an iterator range with a container-like interface
 
 Bug Fixes
-    TODO
+    copy_if now copies in a user provided stream instead of a default_stream
+    {min,max,minmax}_element can now accept raw device pointer with device execution policy
 
 #######################################
 #           Thrust v1.8.2             #

--- a/thrust/system/detail/generic/extrema.inl
+++ b/thrust/system/detail/generic/extrema.inl
@@ -172,7 +172,7 @@ ForwardIterator min_element(thrust::execution_policy<DerivedPolicy> &exec,
       (exec,
        thrust::make_zip_iterator(thrust::make_tuple(first, thrust::counting_iterator<IndexType>(0))),
        thrust::make_zip_iterator(thrust::make_tuple(first, thrust::counting_iterator<IndexType>(0))) + (last - first),
-       thrust::tuple<InputType, IndexType>(*first, 0),
+       thrust::tuple<InputType, IndexType>(get_value(derived_cast(exec), &first[0]), 0),
        detail::min_element_reduction<InputType, IndexType, BinaryPredicate>(comp));
 
   return first + thrust::get<1>(result);
@@ -209,7 +209,7 @@ ForwardIterator max_element(thrust::execution_policy<DerivedPolicy> &exec,
       (exec,
        thrust::make_zip_iterator(thrust::make_tuple(first, thrust::counting_iterator<IndexType>(0))),
        thrust::make_zip_iterator(thrust::make_tuple(first, thrust::counting_iterator<IndexType>(0))) + (last - first),
-       thrust::tuple<InputType, IndexType>(*first, 0),
+       thrust::tuple<InputType, IndexType>(get_value(derived_cast(exec),&first[0]), 0),
        detail::max_element_reduction<InputType, IndexType, BinaryPredicate>(comp));
 
   return first + thrust::get<1>(result);
@@ -247,7 +247,7 @@ thrust::pair<ForwardIterator,ForwardIterator> minmax_element(thrust::execution_p
        thrust::make_zip_iterator(thrust::make_tuple(first, thrust::counting_iterator<IndexType>(0))),
        thrust::make_zip_iterator(thrust::make_tuple(first, thrust::counting_iterator<IndexType>(0))) + (last - first),
        detail::duplicate_tuple<InputType, IndexType>(),
-       detail::duplicate_tuple<InputType, IndexType>()(thrust::tuple<InputType, IndexType>(*first, 0)),
+       detail::duplicate_tuple<InputType, IndexType>()(thrust::tuple<InputType, IndexType>(get_value(derived_cast(exec),&first[0]), 0)),
        detail::minmax_element_reduction<InputType, IndexType, BinaryPredicate>(comp));
 
   return thrust::make_pair(first + thrust::get<1>(thrust::get<0>(result)), first + thrust::get<1>(thrust::get<1>(result)));


### PR DESCRIPTION
Fixes https://github.com/thrust/thrust/issues/776

This allows peeking into the device data when exec is device policy
and the iterator is a raw device pointer, thus fixing
{min,max,minmax}_element in such setup.