### PR TITLE
dereferencing  iterator with  provided execution policy

### DIFF
--- a/thrust/detail/get_iterator_value.h
+++ b/thrust/detail/get_iterator_value.h
@@ -20,30 +20,19 @@
 namespace thrust {
 namespace detail {
 
-// get_iterator_value specialization on iterators
-// --------------------------------------------------
-// it is okay to dereference iterator in usual way
+// dereference an iterator with a provided execution policy
+// This should handle safe derefencing
+// of raw (device) pointer, smart pointer and iterators
 template<typename DerivedPolicy, typename Iterator>
 __host__ __device__
 typename thrust::iterator_traits<Iterator>::value_type
-get_iterator_value(thrust::execution_policy<DerivedPolicy> &, Iterator it)
+get_iterator_value(thrust::execution_policy<DerivedPolicy> &exec, Iterator it)
 {
-  return *it;
+  typename thrust::iterator_traits<Iterator>::value_type value;
+  thrust::detail::two_system_copy_n(exec, thrust::cpp::tag(), 
+                                    it, 1, &value);
+  return value; 
 } // get_iterator_value(exec,Iterator);
-
-// get_iterator_value specialization on pointer
-// ----------------------------------------------
-// we can't just dereference a pointer in usual way, because
-// it may point to a location in the device memory. 
-// we use get_value(exec,pointer*) function
-// to perform a dereferencing consistent with the execution policy
-template<typename DerivedPolicy, typename Pointer>
-__host__ __device__
-typename thrust::detail::pointer_traits<Pointer*>::element_type 
-get_iterator_value(thrust::execution_policy<DerivedPolicy> &exec, Pointer* ptr)
-{
-  return get_value(derived_cast(exec),ptr);
-} // get_iterator_value(exec,Pointer*)
 
 } // namespace detail
 } // namespace thrust


### PR DESCRIPTION
This PR for tracking. Shouldn't be merged just yet because it fails on unit testing [1].  Will proceed with investigation of test failure.

```
================================================================
FAILURE: TestMaxElementDeviceDevice
[testing/backend/cuda/max_element.cu:36] values are not equal: 15 0 [type='long']
================================================================
FAILURE: TestMinElementDeviceDevice
[testing/backend/cuda/min_element.cu:42] values are not equal: 15 0 [type='long']
================================================================
FAILURE: TestMinMaxElementDeviceDevice
[testing/backend/cuda/minmax_element.cu:52] values are not equal: 15 0 [type='long']
```

[1] https://github.com/thrust/thrust/blob/master/testing/backend/cuda/max_element.cu#L53
