### PR TITLE
Avoid assignments and conversions to/from proxy references in block/c…

### DIFF
--- a/thrust/system/cuda/detail/block/copy.h
+++ b/thrust/system/cuda/detail/block/copy.h
@@ -171,7 +171,7 @@ template<typename Context,
       first  += context.block_dimension(),
       result += context.block_dimension())
   {
-    *result = *first;
+    thrust::raw_reference_cast(*result) = thrust::raw_reference_cast(*first);
   } // end for
 
   return end_of_output;
@@ -206,7 +206,7 @@ RandomAccessIterator2 async_copy_n(Context &ctx, RandomAccessIterator1 first, Si
 {
   for(Size i = ctx.thread_index(); i < n; i += ctx.block_dimension())
   {
-    result[i] = first[i];
+    thrust::raw_reference_cast(result[i]) = thrust::raw_reference_cast(first[i]);
   }
 
   return result + n;
@@ -240,7 +240,7 @@ RandomAccessIterator2 async_copy_n_global_to_shared(Context &ctx, RandomAccessIt
     {
       unsigned int idx = ctx.block_dimension() * i + ctx.thread_index();
 
-      reg[i] = first[idx];
+      reg[i] = thrust::raw_reference_cast(first[idx]);
     }
   }
   else
@@ -249,7 +249,7 @@ RandomAccessIterator2 async_copy_n_global_to_shared(Context &ctx, RandomAccessIt
     {
       unsigned int idx = ctx.block_dimension() * i + ctx.thread_index();
 
-      if(idx < n) reg[i] = first[idx];
+      if(idx < n) reg[i] = thrust::raw_reference_cast(first[idx]);
     }
   }
 
@@ -260,7 +260,7 @@ RandomAccessIterator2 async_copy_n_global_to_shared(Context &ctx, RandomAccessIt
     {
       unsigned int idx = ctx.block_dimension() * i + ctx.thread_index();
 
-      result[idx] = reg[i];
+      thrust::raw_reference_cast(result[idx]) = reg[i];
     }
   }
   else
@@ -269,7 +269,7 @@ RandomAccessIterator2 async_copy_n_global_to_shared(Context &ctx, RandomAccessIt
     {
       unsigned int idx = ctx.block_dimension() * i + ctx.thread_index();
 
-      if(idx < n) result[idx] = reg[i];
+      if(idx < n) thrust::raw_reference_cast(result[idx]) = reg[i];
     }
   }
 

--- a/thrust/system/cuda/detail/detail/stable_merge_sort.inl
+++ b/thrust/system/cuda/detail/detail/stable_merge_sort.inl
@@ -36,6 +36,7 @@
 #include <thrust/detail/internal_functional.h>
 #include <thrust/system/cuda/detail/temporary_indirect_permutation.h>
 #include <thrust/system/cuda/detail/runtime_introspection.h>
+#include <thrust/detail/raw_reference_cast.h>
 
 
 namespace thrust
@@ -206,7 +207,7 @@ struct merge_adjacent_partitions_closure
     Size start1 = 0, end1 = 0, start2 = 0, end2 = 0;
 
     thrust::tie(start1,end1,start2,end2) =
-      locate_merge_partitions(n, ctx.block_index(), num_blocks_per_merge, work_per_block, merge_paths[ctx.block_index()], merge_paths[ctx.block_index() + 1]);
+      locate_merge_partitions(n, ctx.block_index(), num_blocks_per_merge, work_per_block, thrust::raw_reference_cast(merge_paths[ctx.block_index()]), thrust::raw_reference_cast(merge_paths[ctx.block_index() + 1]));
 
     block::staged_bounded_merge<work_per_thread>(ctx,
                                                  first + start1, end1 - start1,


### PR DESCRIPTION
…opy & stable_merge_sort

This avoids default-constructing execution policies in thrust::reference when calling
merge sort with a user-defined execution policy.

Fixes #793