### PR TITLE
Adding a full C++11 feature : move constructor and move assignment operator for vector

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,7 @@ Other Enhancements
     anymore when using them with thrust::transform_iterator.
     The performance of thrust::unique* is improved.
     If C++11 support is enabled, the move constructor and move assignment operator have been implemented
-    for host_vector,device_vector,cuda::vector,omp::vector and tbb::vector.
+    for host_vector,device_vector,cpp::vector,cuda::vector,omp::vector and tbb::vector.
 
 Bug Fixes
     TODO

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,8 @@ Other Enhancements
     If C++11 support is enabled, functors do not have to inherit from thrust::unary_function/thrust::binary_function 
     anymore when using them with thrust::transform_iterator.
     The performance of thrust::unique* is improved.
+    If C++11 support is enabled, the move constructor and move assignment operator have been implemented
+    for host_vector,device_vector,cuda::vector,omp::vector and tbb::vector.
 
 Bug Fixes
     TODO
@@ -30,6 +32,7 @@ Known Issues
 Acknowledgments
     Thanks to Manuel Schiller for contributing a C++11 based enhancement regarding the deduction of 
     functor return types, improving the performance of thrust::unique and implementing transform_output_iterator
+    Thanks to Thibault Notargiacomo for the implementation of move semantics for the vector_base based class.
 
 #######################################
 #           Thrust v1.8.3             #

--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -4,9 +4,7 @@
 #include <vector>
 #include <list>
 #include <limits>
-#if __cplusplus >= 201103L
-  #include <utility>
-#endif
+#include <utility>
 
 template <class Vector>
 void TestVectorZeroSize(void)

--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -4,7 +4,9 @@
 #include <vector>
 #include <list>
 #include <limits>
-
+#if __cplusplus >= 201103L
+  #include <utility>
+#endif
 
 template <class Vector>
 void TestVectorZeroSize(void)
@@ -754,3 +756,32 @@ void TestVectorReversed(void)
 }
 DECLARE_VECTOR_UNITTEST(TestVectorReversed);
 
+#if __cplusplus >= 201103L
+  template <class Vector>
+  void TestVectorMoveSemantic(void)
+  {
+    //test move construction
+    Vector v1(3);
+    const auto ptr1 = v1.data();
+    const auto size1 = v1.size();
+
+    Vector v2(std::move(v1));
+    const auto ptr2 = v2.data();
+    const auto size2 = v2.size();
+
+    //test move assignment
+    Vector v3(3);
+    const auto ptr3 = v3.data();
+    const auto size3 = v3.size();
+
+    v2 = std::move(v3);
+    const auto ptr4 = v2.data();
+    const auto size4 = v2.size();
+
+    ASSERT_EQUAL(ptr1, ptr2);
+    ASSERT_EQUAL(size1, size2);
+    ASSERT_EQUAL(ptr3, ptr4);
+    ASSERT_EQUAL(size3, size4);
+  }
+  DECLARE_VECTOR_UNITTEST(TestVectorMoveSemantic);
+#endif

--- a/thrust/detail/vector_base.h
+++ b/thrust/detail/vector_base.h
@@ -83,7 +83,7 @@ template<typename T, typename Alloc>
   #if __cplusplus >= 201103L
     /*! Move constructor use the move semantic over an exemplar
      * vector_base.
-     *  \param v The vector_base to copy.
+     *  \param v The vector_base to move.
      */
     vector_base(vector_base &&v);
   #endif
@@ -96,7 +96,7 @@ template<typename T, typename Alloc>
   #if __cplusplus >= 201103L
     /*! Move assign operator use the move semantic over an exemplar
      * vector_base.
-     *  \param v The vector_base to copy.
+     *  \param v The vector_base to move.
      */
     vector_base &operator=(vector_base &&v);
   #endif

--- a/thrust/detail/vector_base.h
+++ b/thrust/detail/vector_base.h
@@ -80,10 +80,26 @@ template<typename T, typename Alloc>
      */
     vector_base(const vector_base &v);
 
+  #if __cplusplus >= 201103L
+    /*! Move constructor use the move semantic over an exemplar
+     * vector_base.
+     *  \param v The vector_base to copy.
+     */
+    vector_base(vector_base &&v);
+  #endif
+
     /*! assign operator makes a copy of an exemplar vector_base.
      *  \param v The vector_base to copy.
      */
     vector_base &operator=(const vector_base &v);
+
+  #if __cplusplus >= 201103L
+    /*! Move assign operator use the move semantic over an exemplar
+     * vector_base.
+     *  \param v The vector_base to copy.
+     */
+    vector_base &operator=(vector_base &&v);
+  #endif
 
     /*! Copy constructor copies from an exemplar vector_base with different
      *  type.

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -102,7 +102,6 @@ template<typename T, typename Alloc>
       vector_base<T,Alloc>
         ::operator=(vector_base &&v)
   {
-    assert(this != &v);
     vector_base tmp;
     swap(tmp);
     swap(v);

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -102,7 +102,7 @@ template<typename T, typename Alloc>
       vector_base<T,Alloc>
         ::operator=(vector_base &&v)
   {
-    //We don't check for self move assignement : undefined behaviour
+    assert(this != &v);
     vector_base tmp;
     swap(tmp);
     swap(v);

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -74,6 +74,15 @@ template<typename T, typename Alloc>
   range_init(v.begin(), v.end());
 } // end vector_base::vector_base()
 
+#if __cplusplus >= 201103L
+  template<typename T, typename Alloc>
+    vector_base<T,Alloc>
+      ::vector_base(vector_base &&v) : vector_base()
+  {
+    swap(v);
+  } //end vector_base::vector_base()
+#endif
+
 template<typename T, typename Alloc>
   vector_base<T,Alloc> &
     vector_base<T,Alloc>
@@ -86,6 +95,20 @@ template<typename T, typename Alloc>
 
   return *this;
 } // end vector_base::operator=()
+
+#if __cplusplus >= 201103L
+  template<typename T, typename Alloc>
+    vector_base<T,Alloc> &
+      vector_base<T,Alloc>
+        ::operator=(vector_base &&v)
+  {
+    //We don't check for self move assignement : undefined behaviour
+    vector_base tmp;
+    swap(tmp);
+    swap(v);
+    return *this;
+  } // end vector_base::operator=()
+#endif
 
 template<typename T, typename Alloc>
   template<typename OtherT, typename OtherAlloc>

--- a/thrust/device_vector.h
+++ b/thrust/device_vector.h
@@ -109,7 +109,16 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
      __host__
     device_vector(device_vector &&v)
       :Parent(std::forward<Parent>(v)) {}
+  #endif
 
+  /*! Assign operator copies from an exemplar \p device_vector with same type.
+   *  \param v The \p device_vector to copy.
+   */
+  __host__
+  device_vector &operator=(const device_vector &v)
+  { Parent::operator=(v); return *this; }
+
+  #if __cplusplus >= 201103L
     /*! Move assign operator use the move semantic over an exemplar
      * device_vector.
      *  \param v The device_vector to move.
@@ -126,13 +135,6 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
     __device__
     device_vector(const device_vector<OtherT,OtherAlloc> &v)
       :Parent(v) {}
-
-    /*! Assign operator copies from an exemplar \p device_vector with same type.
-     *  \param v The \p device_vector to copy.
-     */
-    __host__
-    device_vector &operator=(const device_vector &v)
-    { Parent::operator=(v); return *this; }
 
     /*! Assign operator copies from an exemplar \p device_vector with different type.
      *  \param v The \p device_vector to copy.

--- a/thrust/device_vector.h
+++ b/thrust/device_vector.h
@@ -25,6 +25,9 @@
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/detail/vector_base.h>
 #include <vector>
+#if __cplusplus >= 201103L
+  #include <utility>
+#endif
 
 namespace thrust
 {
@@ -99,6 +102,31 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
     __host__
     device_vector(const device_vector &v)
       :Parent(v) {}
+
+  #if __cplusplus >= 201103L
+    /*! Move constructor use the move semantic over an exemplar
+     * vector_base.
+     *  \param v The vector_base to copy.
+     */
+     __host__
+    device_vector(device_vector &&v)
+      :Parent(std::forward<Parent>(v)) {}
+
+    /*! Move assign operator use the move semantic over an exemplar
+     * vector_base.
+     *  \param v The vector_base to copy.
+     */
+     __host__
+     device_vector &operator=(device_vector &&v)
+     { Parent::operator=(std::forward<Parent>(v)); return *this; }
+
+     /*! Assign operator copies from an exemplar \p device_vector with different type.
+      *  \param v The \p device_vector to copy.
+      */
+     __host__
+     device_vector &operator=(const device_vector &v)
+     { Parent::operator=(v); return *this; }
+  #endif
 
     /*! Copy constructor copies from an exemplar \p device_vector with different type.
      *  \param v The \p device_vector to copy.

--- a/thrust/device_vector.h
+++ b/thrust/device_vector.h
@@ -25,9 +25,7 @@
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/detail/vector_base.h>
 #include <vector>
-#if __cplusplus >= 201103L
-  #include <utility>
-#endif
+#include <utility>
 
 namespace thrust
 {
@@ -105,16 +103,16 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
 
   #if __cplusplus >= 201103L
     /*! Move constructor use the move semantic over an exemplar
-     * vector_base.
-     *  \param v The vector_base to copy.
+     * device_vector.
+     *  \param v The device_vector to move.
      */
      __host__
     device_vector(device_vector &&v)
       :Parent(std::forward<Parent>(v)) {}
 
     /*! Move assign operator use the move semantic over an exemplar
-     * vector_base.
-     *  \param v The vector_base to copy.
+     * device_vector.
+     *  \param v The device_vector to move.
      */
      __host__
      device_vector &operator=(device_vector &&v)

--- a/thrust/device_vector.h
+++ b/thrust/device_vector.h
@@ -117,13 +117,6 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
      __host__
      device_vector &operator=(device_vector &&v)
      { Parent::operator=(std::forward<Parent>(v)); return *this; }
-
-     /*! Assign operator copies from an exemplar \p device_vector with different type.
-      *  \param v The \p device_vector to copy.
-      */
-     __host__
-     device_vector &operator=(const device_vector &v)
-     { Parent::operator=(v); return *this; }
   #endif
 
     /*! Copy constructor copies from an exemplar \p device_vector with different type.
@@ -133,6 +126,13 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
     __device__
     device_vector(const device_vector<OtherT,OtherAlloc> &v)
       :Parent(v) {}
+
+    /*! Assign operator copies from an exemplar \p device_vector with same type.
+     *  \param v The \p device_vector to copy.
+     */
+    __host__
+    device_vector &operator=(const device_vector &v)
+    { Parent::operator=(v); return *this; }
 
     /*! Assign operator copies from an exemplar \p device_vector with different type.
      *  \param v The \p device_vector to copy.

--- a/thrust/host_vector.h
+++ b/thrust/host_vector.h
@@ -25,6 +25,9 @@
 #include <memory>
 #include <thrust/detail/vector_base.h>
 #include <vector>
+#if __cplusplus >= 201103L
+  #include <utility>
+#endif
 
 namespace thrust
 {
@@ -99,6 +102,24 @@ template<typename T, typename Alloc = std::allocator<T> >
     __host__
     host_vector(const host_vector &v)
       :Parent(v) {}
+
+    #if __cplusplus >= 201103L
+      /*! Move constructor use the move semantic over an exemplar
+       * vector_base.
+       *  \param v The vector_base to copy.
+       */
+       __host__
+      host_vector(host_vector &&v)
+        :Parent(std::forward<Parent>(v)) {}
+
+      /*! Move assign operator use the move semantic over an exemplar
+       * vector_base.
+       *  \param v The vector_base to copy.
+       */
+       __host__
+       host_vector &operator=(host_vector &&v)
+       { Parent::operator=(std::forward<Parent>(v)); return *this; }
+    #endif
 
     /*! Assign operator copies from an exemplar \p host_vector.
      *  \param v The \p host_vector to copy.

--- a/thrust/host_vector.h
+++ b/thrust/host_vector.h
@@ -101,30 +101,32 @@ template<typename T, typename Alloc = std::allocator<T> >
     host_vector(const host_vector &v)
       :Parent(v) {}
 
-    #if __cplusplus >= 201103L
-      /*! Move constructor use the move semantic over an exemplar
-       * host_vector.
-       *  \param v The host_vector to move.
-       */
-       __host__
-      host_vector(host_vector &&v)
-        :Parent(std::forward<Parent>(v)) {}
-
-      /*! Move assign operator use the move semantic over an exemplar
-       * host_vector.
-       *  \param v The host_vector to move.
-       */
-       __host__
-       host_vector &operator=(host_vector &&v)
-       { Parent::operator=(std::forward<Parent>(v)); return *this; }
-    #endif
-
-    /*! Assign operator copies from an exemplar \p host_vector.
-     *  \param v The \p host_vector to copy.
+  #if __cplusplus >= 201103L
+    /*! Move constructor use the move semantic over an exemplar
+     * host_vector.
+     *  \param v The host_vector to move.
      */
-    __host__
-    host_vector &operator=(const host_vector &v)
-    { Parent::operator=(v); return *this; }
+     __host__
+    host_vector(host_vector &&v)
+      :Parent(std::forward<Parent>(v)) {}
+  #endif
+
+  /*! Assign operator copies from an exemplar \p host_vector.
+   *  \param v The \p host_vector to copy.
+   */
+  __host__
+  host_vector &operator=(const host_vector &v)
+  { Parent::operator=(v); return *this; }
+
+  #if __cplusplus >= 201103L
+    /*! Move assign operator use the move semantic over an exemplar
+     * host_vector.
+     *  \param v The host_vector to move.
+     */
+     __host__
+     host_vector &operator=(host_vector &&v)
+     { Parent::operator=(std::forward<Parent>(v)); return *this; }
+  #endif
 
     /*! Copy constructor copies from an exemplar \p host_vector with different type.
      *  \param v The \p host_vector to copy.

--- a/thrust/host_vector.h
+++ b/thrust/host_vector.h
@@ -25,9 +25,7 @@
 #include <memory>
 #include <thrust/detail/vector_base.h>
 #include <vector>
-#if __cplusplus >= 201103L
-  #include <utility>
-#endif
+#include <utility>
 
 namespace thrust
 {
@@ -105,16 +103,16 @@ template<typename T, typename Alloc = std::allocator<T> >
 
     #if __cplusplus >= 201103L
       /*! Move constructor use the move semantic over an exemplar
-       * vector_base.
-       *  \param v The vector_base to copy.
+       * host_vector.
+       *  \param v The host_vector to move.
        */
        __host__
       host_vector(host_vector &&v)
         :Parent(std::forward<Parent>(v)) {}
 
       /*! Move assign operator use the move semantic over an exemplar
-       * vector_base.
-       *  \param v The vector_base to copy.
+       * host_vector.
+       *  \param v The host_vector to move.
        */
        __host__
        host_vector &operator=(host_vector &&v)

--- a/thrust/system/cpp/detail/vector.inl
+++ b/thrust/system/cpp/detail/vector.inl
@@ -81,6 +81,15 @@ template<typename T, typename Allocator>
         : super_t(first,last)
 {}
 
+template<typename T, typename Allocator>
+  vector<T,Allocator> &
+    vector<T,Allocator>
+      ::operator=(const vector &x)
+{
+  super_t::operator=(x);
+  return *this;
+}
+
 #if __cplusplus >= 201103L
   template<typename T, typename Allocator>
     vector<T,Allocator> &

--- a/thrust/system/cpp/detail/vector.inl
+++ b/thrust/system/cpp/detail/vector.inl
@@ -19,6 +19,8 @@
 #include <thrust/detail/config.h>
 #include <thrust/system/cpp/vector.h>
 
+#include <utility>
+
 namespace thrust
 {
 namespace system
@@ -50,6 +52,14 @@ template<typename T, typename Allocator>
       : super_t(x)
 {}
 
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator>
+      ::vector(vector &&x)
+        : super_t(std::forward<super_t>(x))
+  {}
+#endif
+
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>
     vector<T,Allocator>
@@ -70,6 +80,17 @@ template<typename T, typename Allocator>
       ::vector(InputIterator first, InputIterator last)
         : super_t(first,last)
 {}
+
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator> &
+      vector<T,Allocator>
+        ::operator=(vector &&x)
+  {
+    super_t::operator=(std::forward<super_t>(x));
+    return *this;
+  }
+#endif
 
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>

--- a/thrust/system/cpp/vector.h
+++ b/thrust/system/cpp/vector.h
@@ -130,6 +130,12 @@ template<typename T, typename Allocator = allocator<T> >
      *  \return <tt>*this</tt>
      */
      vector &operator=(vector &&x);
+
+     /*! Assignment operator assigns from another \p cpp::vector.
+      *  \param x The other object to assign from.
+      *  \return <tt>*this</tt>
+      */
+     vector &operator=(const vector &x)=default;
   #endif
 
     /*! Assignment operator assigns from a \c std::vector.

--- a/thrust/system/cpp/vector.h
+++ b/thrust/system/cpp/vector.h
@@ -96,6 +96,13 @@ template<typename T, typename Allocator = allocator<T> >
      */
     vector(const vector &x);
 
+  #if __cplusplus >= 201103L
+    /*! Move constructor use the move semantic over another \p cpp::vector.
+     *  \param x The other \p cpp::vector to move from.
+     */
+    vector(vector &&x);
+  #endif
+
     /*! This constructor copies from another Thrust vector-like object.
      *  \param x The other object to copy from.
      */
@@ -116,6 +123,14 @@ template<typename T, typename Allocator = allocator<T> >
     vector(InputIterator first, InputIterator last);
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
+
+  #if __cplusplus >= 201103L
+    /*! Move assignment operator use move semantic over another \p cpp::vector.
+     *  \param x The other \p cpp::vector to move from.
+     *  \return <tt>*this</tt>
+     */
+     vector &operator=(vector &&x);
+  #endif
 
     /*! Assignment operator assigns from a \c std::vector.
      *  \param x The \c std::vector to assign from.

--- a/thrust/system/cpp/vector.h
+++ b/thrust/system/cpp/vector.h
@@ -124,18 +124,18 @@ template<typename T, typename Allocator = allocator<T> >
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
 
+    /*! Assignment operator assigns from another \p cpp::vector.
+     *  \param x The other object to assign from.
+     *  \return <tt>*this</tt>
+     */
+    vector &operator=(const vector &x);
+
   #if __cplusplus >= 201103L
     /*! Move assignment operator use move semantic over another \p cpp::vector.
      *  \param x The other \p cpp::vector to move from.
      *  \return <tt>*this</tt>
      */
      vector &operator=(vector &&x);
-
-     /*! Assignment operator assigns from another \p cpp::vector.
-      *  \param x The other object to assign from.
-      *  \return <tt>*this</tt>
-      */
-     vector &operator=(const vector &x)=default;
   #endif
 
     /*! Assignment operator assigns from a \c std::vector.

--- a/thrust/system/cuda/detail/vector.inl
+++ b/thrust/system/cuda/detail/vector.inl
@@ -81,6 +81,15 @@ template<typename T, typename Allocator>
         : super_t(first,last)
 {}
 
+template<typename T, typename Allocator>
+  vector<T,Allocator> &
+    vector<T,Allocator>
+      ::operator=(const vector &x)
+{
+  super_t::operator=(x);
+  return *this;
+}
+
 #if __cplusplus >= 201103L
   template<typename T, typename Allocator>
     vector<T,Allocator> &

--- a/thrust/system/cuda/detail/vector.inl
+++ b/thrust/system/cuda/detail/vector.inl
@@ -19,6 +19,8 @@
 #include <thrust/detail/config.h>
 #include <thrust/system/cuda/vector.h>
 
+#include <utility>
+
 namespace thrust
 {
 namespace system
@@ -50,6 +52,14 @@ template<typename T, typename Allocator>
       : super_t(x)
 {}
 
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator>
+      ::vector(vector &&x)
+        : super_t(std::forward<super_t>(x))
+  {}
+#endif
+
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>
     vector<T,Allocator>
@@ -70,6 +80,17 @@ template<typename T, typename Allocator>
       ::vector(InputIterator first, InputIterator last)
         : super_t(first,last)
 {}
+
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator> &
+      vector<T,Allocator>
+        ::operator=(vector &&x)
+  {
+    super_t::operator=(std::forward<super_t>(x));
+    return *this;
+  }
+#endif
 
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>

--- a/thrust/system/cuda/vector.h
+++ b/thrust/system/cuda/vector.h
@@ -122,19 +122,19 @@ template<typename T, typename Allocator = allocator<T> >
     vector(InputIterator first, InputIterator last);
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
-    //
+
+    /*! Assignment operator assigns from another \p cuda::vector.
+     *  \param x The other object to assign from.
+     *  \return <tt>*this</tt>
+     */
+    vector &operator=(const vector &x);
+
   #if __cplusplus >= 201103L
     /*! Move assignment operator use move semantic over another \p cuda::vector.
      *  \param x The other \p cuda::vector to move from.
      *  \return <tt>*this</tt>
      */
      vector &operator=(vector &&x);
-
-     /*! Assignment operator assigns from another \p cuda::vector.
-      *  \param x The other object to assign from.
-      *  \return <tt>*this</tt>
-      */
-     vector &operator=(const vector &x)=default;
   #endif
 
     /*! Assignment operator assigns from a \c std::vector.

--- a/thrust/system/cuda/vector.h
+++ b/thrust/system/cuda/vector.h
@@ -129,6 +129,12 @@ template<typename T, typename Allocator = allocator<T> >
      *  \return <tt>*this</tt>
      */
      vector &operator=(vector &&x);
+
+     /*! Assignment operator assigns from another \p cuda::vector.
+      *  \param x The other object to assign from.
+      *  \return <tt>*this</tt>
+      */
+     vector &operator=(const vector &x)=default;
   #endif
 
     /*! Assignment operator assigns from a \c std::vector.

--- a/thrust/system/cuda/vector.h
+++ b/thrust/system/cuda/vector.h
@@ -95,6 +95,13 @@ template<typename T, typename Allocator = allocator<T> >
      */
     vector(const vector &x);
 
+  #if __cplusplus >= 201103L
+    /*! Move constructor use the move semantic over another \p cuda::vector.
+     *  \param x The other \p cuda::vector to move from.
+     */
+    vector(vector &&x);
+  #endif
+
     /*! This constructor copies from another Thrust vector-like object.
      *  \param x The other object to copy from.
      */
@@ -116,6 +123,14 @@ template<typename T, typename Allocator = allocator<T> >
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
     //
+  #if __cplusplus >= 201103L
+    /*! Move assignment operator use move semantic over another \p cuda::vector.
+     *  \param x The other \p cuda::vector to move from.
+     *  \return <tt>*this</tt>
+     */
+     vector &operator=(vector &&x);
+  #endif
+
     /*! Assignment operator assigns from a \c std::vector.
      *  \param x The \c std::vector to assign from.
      *  \return <tt>*this</tt>

--- a/thrust/system/omp/detail/vector.inl
+++ b/thrust/system/omp/detail/vector.inl
@@ -81,6 +81,15 @@ template<typename T, typename Allocator>
         : super_t(first,last)
 {}
 
+template<typename T, typename Allocator>
+  vector<T,Allocator> &
+    vector<T,Allocator>
+      ::operator=(const vector &x)
+{
+  super_t::operator=(x);
+  return *this;
+}
+
 #if __cplusplus >= 201103L
   template<typename T, typename Allocator>
     vector<T,Allocator> &

--- a/thrust/system/omp/detail/vector.inl
+++ b/thrust/system/omp/detail/vector.inl
@@ -19,6 +19,8 @@
 #include <thrust/detail/config.h>
 #include <thrust/system/omp/vector.h>
 
+#include <utility>
+
 namespace thrust
 {
 namespace system
@@ -50,6 +52,14 @@ template<typename T, typename Allocator>
       : super_t(x)
 {}
 
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator>
+      ::vector(vector &&x)
+        : super_t(std::forward<super_t>(x))
+  {}
+#endif
+
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>
     vector<T,Allocator>
@@ -70,6 +80,17 @@ template<typename T, typename Allocator>
       ::vector(InputIterator first, InputIterator last)
         : super_t(first,last)
 {}
+
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator> &
+      vector<T,Allocator>
+        ::operator=(vector &&x)
+  {
+    super_t::operator=(std::forward<super_t>(x));
+    return *this;
+  }
+#endif
 
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>

--- a/thrust/system/omp/vector.h
+++ b/thrust/system/omp/vector.h
@@ -101,6 +101,12 @@ template<typename T, typename Allocator = allocator<T> >
      *  \param x The other \p omp::vector to move from.
      */
     vector(vector &&x);
+
+    /*! Assignment operator assigns from another \p omp::vector.
+     *  \param x The other object to assign from.
+     *  \return <tt>*this</tt>
+     */
+    vector &operator=(const vector &x)=default;
   #endif
 
     /*! This constructor copies from another Thrust vector-like object.

--- a/thrust/system/omp/vector.h
+++ b/thrust/system/omp/vector.h
@@ -101,12 +101,6 @@ template<typename T, typename Allocator = allocator<T> >
      *  \param x The other \p omp::vector to move from.
      */
     vector(vector &&x);
-
-    /*! Assignment operator assigns from another \p omp::vector.
-     *  \param x The other object to assign from.
-     *  \return <tt>*this</tt>
-     */
-    vector &operator=(const vector &x)=default;
   #endif
 
     /*! This constructor copies from another Thrust vector-like object.
@@ -129,6 +123,12 @@ template<typename T, typename Allocator = allocator<T> >
     vector(InputIterator first, InputIterator last);
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
+
+    /*! Assignment operator assigns from another \p omp::vector.
+    *  \param x The other object to assign from.
+    *  \return <tt>*this</tt>
+    */
+   vector &operator=(const vector &x);
 
   #if __cplusplus >= 201103L
     /*! Move assignment operator use move semantic over another \p omp::vector.

--- a/thrust/system/omp/vector.h
+++ b/thrust/system/omp/vector.h
@@ -96,6 +96,13 @@ template<typename T, typename Allocator = allocator<T> >
      */
     vector(const vector &x);
 
+  #if __cplusplus >= 201103L
+    /*! Move constructor use the move semantic over another \p omp::vector.
+     *  \param x The other \p omp::vector to move from.
+     */
+    vector(vector &&x);
+  #endif
+
     /*! This constructor copies from another Thrust vector-like object.
      *  \param x The other object to copy from.
      */
@@ -116,6 +123,14 @@ template<typename T, typename Allocator = allocator<T> >
     vector(InputIterator first, InputIterator last);
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
+
+  #if __cplusplus >= 201103L
+    /*! Move assignment operator use move semantic over another \p omp::vector.
+     *  \param x The other \p omp::vector to move from.
+     *  \return <tt>*this</tt>
+     */
+     vector &operator=(vector &&x);
+  #endif
 
     /*! Assignment operator assigns from a \c std::vector.
      *  \param x The \c std::vector to assign from.

--- a/thrust/system/tbb/detail/vector.inl
+++ b/thrust/system/tbb/detail/vector.inl
@@ -81,6 +81,15 @@ template<typename T, typename Allocator>
         : super_t(first,last)
 {}
 
+template<typename T, typename Allocator>
+  vector<T,Allocator> &
+    vector<T,Allocator>
+      ::operator=(const vector &x)
+{
+  super_t::operator=(x);
+  return *this;
+}
+
 #if __cplusplus >= 201103L
   template<typename T, typename Allocator>
     vector<T,Allocator> &

--- a/thrust/system/tbb/detail/vector.inl
+++ b/thrust/system/tbb/detail/vector.inl
@@ -19,6 +19,8 @@
 #include <thrust/detail/config.h>
 #include <thrust/system/tbb/vector.h>
 
+#include <utility>
+
 namespace thrust
 {
 namespace system
@@ -48,7 +50,15 @@ template<typename T, typename Allocator>
   vector<T,Allocator>
     ::vector(const vector &x)
       : super_t(x)
-{}
+  {}
+
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator>
+      ::vector(vector &&x)
+        : super_t(std::forward<super_t>(x))
+  {}
+#endif
 
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>
@@ -71,6 +81,17 @@ template<typename T, typename Allocator>
         : super_t(first,last)
 {}
 
+#if __cplusplus >= 201103L
+  template<typename T, typename Allocator>
+    vector<T,Allocator> &
+      vector<T,Allocator>
+        ::operator=(vector &&x)
+  {
+    super_t::operator=(std::forward<super_t>(x));
+    return *this;
+  }
+#endif
+
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>
     vector<T,Allocator> &
@@ -90,7 +111,7 @@ template<typename T, typename Allocator>
   super_t::operator=(x);
   return *this;
 }
-      
+    
 } // end tbb
 } // end system
 } // end thrust

--- a/thrust/system/tbb/vector.h
+++ b/thrust/system/tbb/vector.h
@@ -125,6 +125,12 @@ template<typename T, typename Allocator = allocator<T> >
      *  \return <tt>*this</tt>
      */
      vector &operator=(vector &&x);
+
+     /*! Assignment operator assigns from another \p tbb::vector.
+      *  \param x The other object to assign from.
+      *  \return <tt>*this</tt>
+      */
+     vector &operator=(const vector &x)=default;
   #endif
 
     /*! Assignment operator assigns from a \c std::vector.

--- a/thrust/system/tbb/vector.h
+++ b/thrust/system/tbb/vector.h
@@ -119,18 +119,18 @@ template<typename T, typename Allocator = allocator<T> >
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
 
+    /*! Assignment operator assigns from another \p tbb::vector.
+     *  \param x The other object to assign from.
+     *  \return <tt>*this</tt>
+     */
+    vector &operator=(const vector &x);
+
   #if __cplusplus >= 201103L
     /*! Move assignment operator use move semantic over another \p tbb::vector.
      *  \param x The other \p tbb::vector to move from.
      *  \return <tt>*this</tt>
      */
      vector &operator=(vector &&x);
-
-     /*! Assignment operator assigns from another \p tbb::vector.
-      *  \param x The other object to assign from.
-      *  \return <tt>*this</tt>
-      */
-     vector &operator=(const vector &x)=default;
   #endif
 
     /*! Assignment operator assigns from a \c std::vector.

--- a/thrust/system/tbb/vector.h
+++ b/thrust/system/tbb/vector.h
@@ -90,6 +90,13 @@ template<typename T, typename Allocator = allocator<T> >
      *  \param x The other \p tbb::vector to copy.
      */
     vector(const vector &x);
+    
+  #if __cplusplus >= 201103L
+    /*! Move constructor use the move semantic over another \p tbb::vector.
+     *  \param x The other \p tbb::vector to move from.
+     */
+    vector(vector &&x);
+  #endif
 
     /*! This constructor copies from another Thrust vector-like object.
      *  \param x The other object to copy from.
@@ -111,6 +118,14 @@ template<typename T, typename Allocator = allocator<T> >
     vector(InputIterator first, InputIterator last);
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
+
+  #if __cplusplus >= 201103L
+    /*! Move assignment operator use move semantic over another \p tbb::vector.
+     *  \param x The other \p tbb::vector to move from.
+     *  \return <tt>*this</tt>
+     */
+     vector &operator=(vector &&x);
+  #endif
 
     /*! Assignment operator assigns from a \c std::vector.
      *  \param x The \c std::vector to assign from.


### PR DESCRIPTION
I did a very simple, yet working implementation of move semantic, that is not the default c++11 implementation.

Here are some question you may ask:

Why C++11 default implementation is not good ?
 -There is not implicit default move semantic for all thrust vector class because copy constructor, copy assignment operator and destructor are already user-declared, see (http://stackoverflow.com/questions/4819936/why-no-default-move-assignment-move-constructor) for references

Why defaulted C++11 implementation is not good ?
 -because it does not necessarily initialize the "void" new object with its default constructor, depending on the type of the pointer/size member it can even just make a copy.
If a copy is performed, when deleting the temporary object, weird behaviour can occur, ie, pointer or size of the object moved from can keep their old value or take random values, and we may delete either a random pointer or more probably the valid pointer that as been copied in the move operation /!\.

Why so few modifications ?
 -because the swap operator was already defined in vector_base
 -because device_vector and host_vector does not define their own members attributes.

Why did you defined assignment operator in device_vector ?
 -because it wasn't defined before, and because, defining the move assignment operator automatically makes it deleted.

Why do the unit test does not execute when I build ?
 -I did not found example of how to add pure c++11 test in the scons script, so I modified it by hand, by adding
```
my_env.Append(CPPFLAGS = '-std=c++11')
in testing/SConscript line 23
```
and I get the following results under linux:
```
[PASS]          0 ms TestVectorMoveSemanticDevice
[PASS]          0 ms TestVectorMoveSemanticHost
```