### PR TITLE
Move constructors

### DIFF
--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -756,10 +756,12 @@ DECLARE_VECTOR_UNITTEST(TestVectorReversed);
 
 #if __cplusplus >= 201103L
   template <class Vector>
-  void TestVectorMoveSemantic(void)
+  void TestVectorMove(void)
   {
     //test move construction
     Vector v1(3);
+    v1[0] = 0; v1[1] = 1; v1[2] = 2;
+
     const auto ptr1 = v1.data();
     const auto size1 = v1.size();
 
@@ -767,8 +769,22 @@ DECLARE_VECTOR_UNITTEST(TestVectorReversed);
     const auto ptr2 = v2.data();
     const auto size2 = v2.size();
 
+    // ensure v1 was left empty
+    ASSERT_EQUAL(true, v1.empty());
+
+    // ensure v2 received the data from before
+    ASSERT_EQUAL(v2[0], 0);
+    ASSERT_EQUAL(v2[1], 1);
+    ASSERT_EQUAL(v2[2], 2);
+    ASSERT_EQUAL(size1, size2);
+
+    // ensure v2 received the pointer from before
+    ASSERT_EQUAL(ptr1, ptr2);
+
     //test move assignment
     Vector v3(3);
+    v3[0] = 3; v3[1] = 4; v3[2] = 5;
+
     const auto ptr3 = v3.data();
     const auto size3 = v3.size();
 
@@ -776,10 +792,18 @@ DECLARE_VECTOR_UNITTEST(TestVectorReversed);
     const auto ptr4 = v2.data();
     const auto size4 = v2.size();
 
-    ASSERT_EQUAL(ptr1, ptr2);
-    ASSERT_EQUAL(size1, size2);
-    ASSERT_EQUAL(ptr3, ptr4);
+    // ensure v3 was left empty
+    ASSERT_EQUAL(true, v3.empty());
+
+    // ensure v2 received the data from before
+    ASSERT_EQUAL(v2[0], 3);
+    ASSERT_EQUAL(v2[1], 4);
+    ASSERT_EQUAL(v2[2], 5);
     ASSERT_EQUAL(size3, size4);
+
+    // ensure v2 received the pointer from before
+    ASSERT_EQUAL(ptr3, ptr4);
   }
-  DECLARE_VECTOR_UNITTEST(TestVectorMoveSemantic);
+  DECLARE_VECTOR_UNITTEST(TestVectorMove);
 #endif
+

--- a/thrust/detail/vector_base.h
+++ b/thrust/detail/vector_base.h
@@ -81,21 +81,19 @@ template<typename T, typename Alloc>
     vector_base(const vector_base &v);
 
   #if __cplusplus >= 201103L
-    /*! Move constructor use the move semantic over an exemplar
-     * vector_base.
+    /*! Move constructor moves from another vector_base.
      *  \param v The vector_base to move.
      */
     vector_base(vector_base &&v);
   #endif
 
-    /*! assign operator makes a copy of an exemplar vector_base.
+    /*! Copy assign operator copies from another vector_base.
      *  \param v The vector_base to copy.
      */
     vector_base &operator=(const vector_base &v);
 
   #if __cplusplus >= 201103L
-    /*! Move assign operator use the move semantic over an exemplar
-     * vector_base.
+    /*! Move assign operator moves from another vector_base.
      *  \param v The vector_base to move.
      */
     vector_base &operator=(vector_base &&v);

--- a/thrust/device_vector.h
+++ b/thrust/device_vector.h
@@ -102,16 +102,15 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
       :Parent(v) {}
 
   #if __cplusplus >= 201103L
-    /*! Move constructor use the move semantic over an exemplar
-     * device_vector.
+    /*! Move constructor moves from another \p device_vector.
      *  \param v The device_vector to move.
      */
      __host__
     device_vector(device_vector &&v)
-      :Parent(std::forward<Parent>(v)) {}
+      :Parent(std::move(v)) {}
   #endif
 
-  /*! Assign operator copies from an exemplar \p device_vector with same type.
+  /*! Copy assign operator copies another \p device_vector with the same type.
    *  \param v The \p device_vector to copy.
    */
   __host__
@@ -119,13 +118,12 @@ template<typename T, typename Alloc = thrust::device_malloc_allocator<T> >
   { Parent::operator=(v); return *this; }
 
   #if __cplusplus >= 201103L
-    /*! Move assign operator use the move semantic over an exemplar
-     * device_vector.
+    /*! Move assign operator moves from another \p device_vector.
      *  \param v The device_vector to move.
      */
      __host__
      device_vector &operator=(device_vector &&v)
-     { Parent::operator=(std::forward<Parent>(v)); return *this; }
+     { Parent::operator=(std::move(v)); return *this; }
   #endif
 
     /*! Copy constructor copies from an exemplar \p device_vector with different type.

--- a/thrust/host_vector.h
+++ b/thrust/host_vector.h
@@ -102,13 +102,12 @@ template<typename T, typename Alloc = std::allocator<T> >
       :Parent(v) {}
 
   #if __cplusplus >= 201103L
-    /*! Move constructor use the move semantic over an exemplar
-     * host_vector.
+    /*! Move constructor moves from another host_vector.
      *  \param v The host_vector to move.
      */
      __host__
     host_vector(host_vector &&v)
-      :Parent(std::forward<Parent>(v)) {}
+      :Parent(std::move(v)) {}
   #endif
 
   /*! Assign operator copies from an exemplar \p host_vector.
@@ -119,13 +118,12 @@ template<typename T, typename Alloc = std::allocator<T> >
   { Parent::operator=(v); return *this; }
 
   #if __cplusplus >= 201103L
-    /*! Move assign operator use the move semantic over an exemplar
-     * host_vector.
+    /*! Move assign operator moves from another host_vector.
      *  \param v The host_vector to move.
      */
      __host__
      host_vector &operator=(host_vector &&v)
-     { Parent::operator=(std::forward<Parent>(v)); return *this; }
+     { Parent::operator=(std::move(v)); return *this; }
   #endif
 
     /*! Copy constructor copies from an exemplar \p host_vector with different type.

--- a/thrust/system/cpp/detail/vector.inl
+++ b/thrust/system/cpp/detail/vector.inl
@@ -18,7 +18,6 @@
 
 #include <thrust/detail/config.h>
 #include <thrust/system/cpp/vector.h>
-
 #include <utility>
 
 namespace thrust
@@ -56,7 +55,7 @@ template<typename T, typename Allocator>
   template<typename T, typename Allocator>
     vector<T,Allocator>
       ::vector(vector &&x)
-        : super_t(std::forward<super_t>(x))
+        : super_t(std::move(x))
   {}
 #endif
 
@@ -96,7 +95,7 @@ template<typename T, typename Allocator>
       vector<T,Allocator>
         ::operator=(vector &&x)
   {
-    super_t::operator=(std::forward<super_t>(x));
+    super_t::operator=(std::move(x));
     return *this;
   }
 #endif

--- a/thrust/system/cpp/vector.h
+++ b/thrust/system/cpp/vector.h
@@ -97,7 +97,7 @@ template<typename T, typename Allocator = allocator<T> >
     vector(const vector &x);
 
   #if __cplusplus >= 201103L
-    /*! Move constructor use the move semantic over another \p cpp::vector.
+    /*! Move constructor moves from over another \p cpp::vector.
      *  \param x The other \p cpp::vector to move from.
      */
     vector(vector &&x);
@@ -131,7 +131,7 @@ template<typename T, typename Allocator = allocator<T> >
     vector &operator=(const vector &x);
 
   #if __cplusplus >= 201103L
-    /*! Move assignment operator use move semantic over another \p cpp::vector.
+    /*! Move assignment operator moves from another \p cpp::vector.
      *  \param x The other \p cpp::vector to move from.
      *  \return <tt>*this</tt>
      */

--- a/thrust/system/cuda/detail/vector.inl
+++ b/thrust/system/cuda/detail/vector.inl
@@ -18,7 +18,6 @@
 
 #include <thrust/detail/config.h>
 #include <thrust/system/cuda/vector.h>
-
 #include <utility>
 
 namespace thrust
@@ -56,7 +55,7 @@ template<typename T, typename Allocator>
   template<typename T, typename Allocator>
     vector<T,Allocator>
       ::vector(vector &&x)
-        : super_t(std::forward<super_t>(x))
+        : super_t(std::move(x))
   {}
 #endif
 
@@ -96,7 +95,7 @@ template<typename T, typename Allocator>
       vector<T,Allocator>
         ::operator=(vector &&x)
   {
-    super_t::operator=(std::forward<super_t>(x));
+    super_t::operator=(std::move(x));
     return *this;
   }
 #endif

--- a/thrust/system/cuda/vector.h
+++ b/thrust/system/cuda/vector.h
@@ -96,7 +96,7 @@ template<typename T, typename Allocator = allocator<T> >
     vector(const vector &x);
 
   #if __cplusplus >= 201103L
-    /*! Move constructor use the move semantic over another \p cuda::vector.
+    /*! Move constructor moves another \p cuda::vector.
      *  \param x The other \p cuda::vector to move from.
      */
     vector(vector &&x);
@@ -123,14 +123,14 @@ template<typename T, typename Allocator = allocator<T> >
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
 
-    /*! Assignment operator assigns from another \p cuda::vector.
+    /*! Copy assignment operator assigns from another \p cuda::vector.
      *  \param x The other object to assign from.
      *  \return <tt>*this</tt>
      */
     vector &operator=(const vector &x);
 
   #if __cplusplus >= 201103L
-    /*! Move assignment operator use move semantic over another \p cuda::vector.
+    /*! Move assignment operator moves another \p cuda::vector.
      *  \param x The other \p cuda::vector to move from.
      *  \return <tt>*this</tt>
      */

--- a/thrust/system/omp/detail/vector.inl
+++ b/thrust/system/omp/detail/vector.inl
@@ -18,7 +18,6 @@
 
 #include <thrust/detail/config.h>
 #include <thrust/system/omp/vector.h>
-
 #include <utility>
 
 namespace thrust
@@ -56,7 +55,7 @@ template<typename T, typename Allocator>
   template<typename T, typename Allocator>
     vector<T,Allocator>
       ::vector(vector &&x)
-        : super_t(std::forward<super_t>(x))
+        : super_t(std::move(x))
   {}
 #endif
 
@@ -96,7 +95,7 @@ template<typename T, typename Allocator>
       vector<T,Allocator>
         ::operator=(vector &&x)
   {
-    super_t::operator=(std::forward<super_t>(x));
+    super_t::operator=(std::move(x));
     return *this;
   }
 #endif

--- a/thrust/system/omp/vector.h
+++ b/thrust/system/omp/vector.h
@@ -97,7 +97,7 @@ template<typename T, typename Allocator = allocator<T> >
     vector(const vector &x);
 
   #if __cplusplus >= 201103L
-    /*! Move constructor use the move semantic over another \p omp::vector.
+    /*! Move constructor moves another \p omp::vector.
      *  \param x The other \p omp::vector to move from.
      */
     vector(vector &&x);
@@ -124,15 +124,15 @@ template<typename T, typename Allocator = allocator<T> >
 
     // XXX vector_base should take a Derived type so we don't have to define these superfluous assigns
 
-    /*! Assignment operator assigns from another \p omp::vector.
+    /*! Copy assignment operator assigns from another \p omp::vector.
     *  \param x The other object to assign from.
     *  \return <tt>*this</tt>
     */
    vector &operator=(const vector &x);
 
   #if __cplusplus >= 201103L
-    /*! Move assignment operator use move semantic over another \p omp::vector.
-     *  \param x The other \p omp::vector to move from.
+    /*! Move assignment operator moves another \p omp::vector.
+     *  \param x The other \p omp::vector to move.
      *  \return <tt>*this</tt>
      */
      vector &operator=(vector &&x);

--- a/thrust/system/tbb/detail/vector.inl
+++ b/thrust/system/tbb/detail/vector.inl
@@ -18,7 +18,6 @@
 
 #include <thrust/detail/config.h>
 #include <thrust/system/tbb/vector.h>
-
 #include <utility>
 
 namespace thrust
@@ -56,7 +55,7 @@ template<typename T, typename Allocator>
   template<typename T, typename Allocator>
     vector<T,Allocator>
       ::vector(vector &&x)
-        : super_t(std::forward<super_t>(x))
+        : super_t(std::move(x))
   {}
 #endif
 
@@ -96,7 +95,7 @@ template<typename T, typename Allocator>
       vector<T,Allocator>
         ::operator=(vector &&x)
   {
-    super_t::operator=(std::forward<super_t>(x));
+    super_t::operator=(std::move(x));
     return *this;
   }
 #endif


### PR DESCRIPTION
This pull request

  * enhances the `TestVectorMove` unit test
  * uses `std::move()` instead of `std::forward<super_t>()` in vector move operations
  * tweaks the language of the move operation documentation a little bit