### PR TITLE
fix warnings when compile with clang

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -385,7 +385,7 @@ def command_line_variables():
                         ['sm_10', 'sm_11', 'sm_12', 'sm_13',
                          'sm_20', 'sm_21',
                          'sm_30', 'sm_32', 'sm_35', 'sm_37',
-                         'sm_50']))
+                         'sm_50', 'sm_52']))
 
   # add a variable to handle CUDA dynamic parallelism
   vars.Add(BoolVariable('cdp', 'Enable CUDA dynamic parallelism', False))

--- a/testing/backend/cuda/copy_if.cu
+++ b/testing/backend/cuda/copy_if.cu
@@ -90,7 +90,6 @@ DECLARE_UNITTEST(TestCopyIfDeviceDevice);
 void TestCopyIfCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -104,11 +103,11 @@ void TestCopyIfCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::copy_if(thrust::cuda::par.on(s),
-                                                  data.begin(), 
-                                                  data.end(), 
-                                                  result.begin(),
-                                                  is_even<int>());
+  Vector::iterator end = thrust::copy_if(thrust::cuda::par.on(s),
+                                         data.begin(), 
+                                         data.end(), 
+                                         result.begin(),
+                                         is_even<int>());
 
   ASSERT_EQUAL(end - result.begin(), 2);
 
@@ -196,7 +195,7 @@ DECLARE_UNITTEST(TestCopyIfStencilDeviceDevice);
 void TestCopyIfStencilCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -217,12 +216,12 @@ void TestCopyIfStencilCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::copy_if(thrust::cuda::par.on(s),
-                                                  data.begin(), 
-                                                  data.end(),
-                                                  stencil.begin(),
-                                                  result.begin(),
-                                                  thrust::identity<T>());
+  Vector::iterator end = thrust::copy_if(thrust::cuda::par.on(s),
+                                         data.begin(), 
+                                         data.end(),
+                                         stencil.begin(),
+                                         result.begin(),
+                                         thrust::identity<T>());
 
   ASSERT_EQUAL(end - result.begin(), 2);
 

--- a/testing/backend/cuda/is_sorted_until.cu
+++ b/testing/backend/cuda/is_sorted_until.cu
@@ -53,8 +53,8 @@ void TestIsSortedUntilCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
 
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::value_type T;
+  typedef Vector::iterator Iterator;
 
   cudaStream_t s;
   cudaStreamCreate(&s);

--- a/testing/backend/cuda/logical.cu
+++ b/testing/backend/cuda/logical.cu
@@ -58,7 +58,7 @@ DECLARE_UNITTEST(TestAllOfDeviceDevice);
 void TestAllOfCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
   
   Vector v(3, 1);
 
@@ -136,7 +136,7 @@ DECLARE_UNITTEST(TestAnyOfDeviceDevice);
 void TestAnyOfCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector v(3, 1);
 
@@ -214,7 +214,7 @@ DECLARE_UNITTEST(TestNoneOfDeviceDevice);
 void TestNoneOfCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector v(3, 1);
 

--- a/testing/backend/cuda/max_element.cu
+++ b/testing/backend/cuda/max_element.cu
@@ -60,7 +60,7 @@ DECLARE_UNITTEST(TestMaxElementDeviceDevice);
 void TestMaxElementCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(6);
   data[0] = 3;
@@ -86,7 +86,7 @@ DECLARE_UNITTEST(TestMaxElementCudaStreams);
 void TestMaxElementDevicePointer()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(6);
   data[0] = 3;

--- a/testing/backend/cuda/merge.cu
+++ b/testing/backend/cuda/merge.cu
@@ -82,7 +82,7 @@ DECLARE_UNITTEST(TestMergeDeviceDevice);
 void TestMergeCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a(3), b(4);
 

--- a/testing/backend/cuda/merge_by_key.cu
+++ b/testing/backend/cuda/merge_by_key.cu
@@ -86,7 +86,7 @@ DECLARE_UNITTEST(TestMergeByKeyDeviceDevice);
 void TestMergeByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a_key(3), a_val(3), b_key(4), b_val(4);
 

--- a/testing/backend/cuda/merge_sort.cu
+++ b/testing/backend/cuda/merge_sort.cu
@@ -90,7 +90,7 @@ void InitializeSimpleStableKeySortTest(Vector& unsorted_keys, Vector& sorted_key
 void TestMergeSortKeySimple(void)
 {
     typedef thrust::device_vector<int> Vector;
-    typedef typename Vector::value_type T;
+    typedef Vector::value_type T;
 
     Vector unsorted_keys;
     Vector   sorted_keys;
@@ -108,7 +108,7 @@ DECLARE_UNITTEST(TestMergeSortKeySimple);
 void TestMergeSortKeyValueSimple(void)
 {
     typedef thrust::device_vector<int> Vector;
-    typedef typename Vector::value_type T;
+    typedef Vector::value_type T;
 
     Vector unsorted_keys, unsorted_values;
     Vector   sorted_keys,   sorted_values;
@@ -127,7 +127,7 @@ DECLARE_UNITTEST(TestMergeSortKeyValueSimple);
 void TestMergeSortStableKeySimple(void)
 {
     typedef thrust::device_vector<int> Vector;
-    typedef typename Vector::value_type T;
+    typedef Vector::value_type T;
 
     Vector unsorted_keys;
     Vector   sorted_keys;

--- a/testing/backend/cuda/min_element.cu
+++ b/testing/backend/cuda/min_element.cu
@@ -60,7 +60,7 @@ DECLARE_UNITTEST(TestMinElementDeviceDevice);
 void TestMinElementCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(6);
   data[0] = 3;
@@ -86,7 +86,7 @@ DECLARE_UNITTEST(TestMinElementCudaStreams);
 void TestMinElementDevicePointer()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(6);
   data[0] = 3;

--- a/testing/backend/cuda/minmax_element.cu
+++ b/testing/backend/cuda/minmax_element.cu
@@ -80,7 +80,6 @@ DECLARE_UNITTEST(TestMinMaxElementDeviceDevice);
 void TestMinMaxElementCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
 
   Vector data(6);
   data[0] = 3;
@@ -105,7 +104,7 @@ DECLARE_UNITTEST(TestMinMaxElementCudaStreams);
 void TestMinMaxElementDevicePointer()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(6);
   data[0] = 3;

--- a/testing/backend/cuda/mismatch.cu
+++ b/testing/backend/cuda/mismatch.cu
@@ -63,7 +63,6 @@ DECLARE_UNITTEST(TestMismatchDeviceDevice);
 void TestMismatchCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
 
   Vector a(4); Vector b(4);
   a[0] = 1; b[0] = 1;

--- a/testing/backend/cuda/partition.cu
+++ b/testing/backend/cuda/partition.cu
@@ -509,8 +509,8 @@ DECLARE_UNITTEST(TestStablePartitionCopyStencilDeviceDevice);
 void TestPartitionCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator   Iterator;
+  typedef Vector::value_type T;
+  typedef Vector::iterator   Iterator;
   
   Vector data(5);
   data[0] = 1; 

--- a/testing/backend/cuda/partition_point.cu
+++ b/testing/backend/cuda/partition_point.cu
@@ -53,8 +53,8 @@ DECLARE_UNITTEST(TestPartitionPointDeviceDevice);
 void TestPartitionPointCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::value_type T;
+  typedef Vector::iterator Iterator;
 
   Vector v(4);
   v[0] = 1; v[1] = 1; v[2] = 1; v[3] = 0;

--- a/testing/backend/cuda/reduce.cu
+++ b/testing/backend/cuda/reduce.cu
@@ -54,7 +54,6 @@ VariableUnitTest<TestReduceDeviceDevice, IntegralTypes> TestReduceDeviceDeviceIn
 void TestReduceCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
 
   Vector v(3);
   v[0] = 1; v[1] = -2; v[2] = 3;

--- a/testing/backend/cuda/reduce_by_key.cu
+++ b/testing/backend/cuda/reduce_by_key.cu
@@ -179,12 +179,12 @@ DECLARE_UNITTEST(TestReduceByKeyDeviceDevice);
 void TestReduceByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector keys;
   Vector values;
 
-  typename thrust::pair<typename Vector::iterator, typename Vector::iterator> new_last;
+  thrust::pair<Vector::iterator, Vector::iterator> new_last;
 
   // basic test
   initialize_keys(keys);  initialize_values(values);

--- a/testing/backend/cuda/remove.cu
+++ b/testing/backend/cuda/remove.cu
@@ -313,7 +313,7 @@ DECLARE_UNITTEST(TestRemoveCopyIfStencilDeviceDevice);
 void TestRemoveCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -325,10 +325,10 @@ void TestRemoveCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::remove(thrust::cuda::par.on(s),
-                                                 data.begin(), 
-                                                 data.end(), 
-                                                 (T) 2);
+  Vector::iterator end = thrust::remove(thrust::cuda::par.on(s),
+                                        data.begin(), 
+                                        data.end(), 
+                                        (T) 2);
 
   ASSERT_EQUAL(end - data.begin(), 3);
 
@@ -344,7 +344,7 @@ DECLARE_UNITTEST(TestRemoveCudaStreams);
 void TestRemoveCopyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -358,11 +358,11 @@ void TestRemoveCopyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::remove_copy(thrust::cuda::par.on(s),
-                                                      data.begin(), 
-                                                      data.end(), 
-                                                      result.begin(), 
-                                                      (T) 2);
+  Vector::iterator end = thrust::remove_copy(thrust::cuda::par.on(s),
+                                             data.begin(), 
+                                             data.end(), 
+                                             result.begin(), 
+                                             (T) 2);
 
   ASSERT_EQUAL(end - result.begin(), 3);
 
@@ -378,7 +378,7 @@ DECLARE_UNITTEST(TestRemoveCopyCudaStreams);
 void TestRemoveIfCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -390,10 +390,10 @@ void TestRemoveIfCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s),
-                                                    data.begin(), 
-                                                    data.end(), 
-                                                    is_even<T>());
+  Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s),
+                                           data.begin(), 
+                                           data.end(), 
+                                           is_even<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
 
@@ -409,7 +409,7 @@ DECLARE_UNITTEST(TestRemoveIfCudaStreams);
 void TestRemoveIfStencilCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -428,11 +428,11 @@ void TestRemoveIfStencilCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s),
-                                                    data.begin(), 
-                                                    data.end(),
-                                                    stencil.begin(),
-                                                    thrust::identity<T>());
+  Vector::iterator end = thrust::remove_if(thrust::cuda::par.on(s),
+                                           data.begin(), 
+                                           data.end(),
+                                           stencil.begin(),
+                                           thrust::identity<T>());
 
   ASSERT_EQUAL(end - data.begin(), 3);
 
@@ -448,7 +448,7 @@ DECLARE_UNITTEST(TestRemoveIfStencilCudaStreams);
 void TestRemoveCopyIfCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -462,11 +462,11 @@ void TestRemoveCopyIfCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::remove_copy_if(thrust::cuda::par.on(s),
-                                                         data.begin(), 
-                                                         data.end(), 
-                                                         result.begin(), 
-                                                         is_even<T>());
+  Vector::iterator end = thrust::remove_copy_if(thrust::cuda::par.on(s),
+                                                data.begin(), 
+                                                data.end(), 
+                                                result.begin(), 
+                                                is_even<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
 
@@ -482,7 +482,7 @@ DECLARE_UNITTEST(TestRemoveCopyIfCudaStreams);
 void TestRemoveCopyIfStencilCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 
@@ -503,12 +503,12 @@ void TestRemoveCopyIfStencilCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  typename Vector::iterator end = thrust::remove_copy_if(thrust::cuda::par.on(s),
-                                                         data.begin(), 
-                                                         data.end(), 
-                                                         stencil.begin(),
-                                                         result.begin(), 
-                                                         thrust::identity<T>());
+  Vector::iterator end = thrust::remove_copy_if(thrust::cuda::par.on(s),
+                                                data.begin(), 
+                                                data.end(), 
+                                                stencil.begin(),
+                                                result.begin(), 
+                                                thrust::identity<T>());
 
   ASSERT_EQUAL(end - result.begin(), 3);
 

--- a/testing/backend/cuda/replace.cu
+++ b/testing/backend/cuda/replace.cu
@@ -245,7 +245,7 @@ DECLARE_UNITTEST(TestReplaceCopyIfStencilDeviceDevice);
 void TestReplaceCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
   Vector data(5);
   data[0] =  1; 

--- a/testing/backend/cuda/scan.cu
+++ b/testing/backend/cuda/scan.cu
@@ -91,9 +91,9 @@ VariableUnitTest<TestScanDeviceDevice, IntegralTypes> TestScanDeviceDeviceInstan
 void TestScanCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
   
-  typename Vector::iterator iter;
+  Vector::iterator iter;
 
   Vector input(5);
   Vector result(5);

--- a/testing/backend/cuda/scan_by_key.cu
+++ b/testing/backend/cuda/scan_by_key.cu
@@ -98,8 +98,8 @@ DECLARE_UNITTEST(TestScanByKeyDeviceDevice);
 void TestInclusiveScanByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator   Iterator;
+  typedef Vector::value_type T;
+  typedef Vector::iterator   Iterator;
 
   Vector keys(7);
   Vector vals(7);
@@ -160,8 +160,8 @@ DECLARE_UNITTEST(TestInclusiveScanByKeyCudaStreams);
 void TestExclusiveScanByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
-  typedef typename Vector::iterator   Iterator;
+  typedef Vector::value_type T;
+  typedef Vector::iterator   Iterator;
 
   Vector keys(7);
   Vector vals(7);

--- a/testing/backend/cuda/scatter.cu
+++ b/testing/backend/cuda/scatter.cu
@@ -111,7 +111,6 @@ DECLARE_UNITTEST(TestScatterIfDeviceDevice);
 void TestScatterCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
 
   Vector map(5);  // scatter indices
   Vector src(5);  // source vector
@@ -145,7 +144,6 @@ DECLARE_UNITTEST(TestScatterCudaStreams);
 void TestScatterIfCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
   
   Vector flg(5);  // predicate array
   Vector map(5);  // scatter indices

--- a/testing/backend/cuda/sequence.cu
+++ b/testing/backend/cuda/sequence.cu
@@ -72,7 +72,6 @@ DECLARE_UNITTEST(TestSequenceDeviceDevice);
 void TestSequenceCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
   
   Vector v(5);
 

--- a/testing/backend/cuda/set_difference.cu
+++ b/testing/backend/cuda/set_difference.cu
@@ -55,7 +55,7 @@ DECLARE_UNITTEST(TestSetDifferenceDeviceDevice);
 void TestSetDifferenceCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a(4), b(5);
 

--- a/testing/backend/cuda/set_difference_by_key.cu
+++ b/testing/backend/cuda/set_difference_by_key.cu
@@ -85,7 +85,7 @@ DECLARE_UNITTEST(TestSetDifferenceByKeyDeviceDevice);
 void TestSetDifferenceByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a_key(4), b_key(5);
   Vector a_val(4), b_val(5);

--- a/testing/backend/cuda/set_intersection.cu
+++ b/testing/backend/cuda/set_intersection.cu
@@ -21,7 +21,7 @@ template<typename ExecutionPolicy>
 void TestSetIntersectionDevice(ExecutionPolicy exec)
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a(3), b(4);
 
@@ -59,7 +59,7 @@ DECLARE_UNITTEST(TestSetIntersectionDeviceDevice);
 void TestSetIntersectionCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a(3), b(4);
 

--- a/testing/backend/cuda/set_intersection_by_key.cu
+++ b/testing/backend/cuda/set_intersection_by_key.cu
@@ -74,7 +74,7 @@ DECLARE_UNITTEST(TestSetIntersectionByKeyDeviceDevice);
 void TestSetIntersectionByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a_key(3), b_key(4);
   Vector a_val(3);

--- a/testing/backend/cuda/set_symmetric_difference.cu
+++ b/testing/backend/cuda/set_symmetric_difference.cu
@@ -61,7 +61,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceDeviceDevice);
 void TestSetSymmetricDifferenceCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a(4), b(5);
 

--- a/testing/backend/cuda/set_symmetric_difference_by_key.cu
+++ b/testing/backend/cuda/set_symmetric_difference_by_key.cu
@@ -76,7 +76,7 @@ DECLARE_UNITTEST(TestSetSymmetricDifferenceByKeyDeviceDevice);
 void TestSetSymmetricDifferenceByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a_key(4), b_key(5);
   Vector a_val(4), b_val(5);

--- a/testing/backend/cuda/set_union.cu
+++ b/testing/backend/cuda/set_union.cu
@@ -61,7 +61,7 @@ DECLARE_UNITTEST(TestSetUnionDeviceDevice);
 void TestSetUnionCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a(3), b(4);
 

--- a/testing/backend/cuda/set_union_by_key.cu
+++ b/testing/backend/cuda/set_union_by_key.cu
@@ -75,7 +75,7 @@ DECLARE_UNITTEST(TestSetUnionByKeyDeviceDevice);
 void TestSetUnionByKeyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::iterator Iterator;
+  typedef Vector::iterator Iterator;
 
   Vector a_key(3), b_key(4);
   Vector a_val(3), b_val(4);

--- a/testing/backend/cuda/swap_ranges.cu
+++ b/testing/backend/cuda/swap_ranges.cu
@@ -15,7 +15,6 @@ template<typename ExecutionPolicy>
 void TestSwapRangesDevice(ExecutionPolicy exec)
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
 
   Vector v1(5);
   v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;
@@ -53,7 +52,6 @@ DECLARE_UNITTEST(TestSwapRangesDeviceDevice);
 void TestSwapRangesCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
 
   Vector v1(5);
   v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;

--- a/testing/backend/cuda/tabulate.cu
+++ b/testing/backend/cuda/tabulate.cu
@@ -62,7 +62,7 @@ void TestTabulateCudaStreams()
 {
   using namespace thrust::placeholders;
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
   
   Vector v(5);
 

--- a/testing/backend/cuda/transform.cu
+++ b/testing/backend/cuda/transform.cu
@@ -260,9 +260,9 @@ DECLARE_UNITTEST(TestTransformIfBinaryDeviceDevice);
 void TestTransformUnaryCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
   
-  typename Vector::iterator iter;
+  Vector::iterator iter;
 
   Vector input(3);
   Vector output(3);
@@ -287,9 +287,9 @@ DECLARE_UNITTEST(TestTransformUnaryCudaStreams);
 void TestTransformBinaryCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
-  typename Vector::iterator iter;
+  Vector::iterator iter;
 
   Vector input1(3);
   Vector input2(3);

--- a/testing/backend/cuda/transform_reduce.cu
+++ b/testing/backend/cuda/transform_reduce.cu
@@ -47,7 +47,7 @@ DECLARE_UNITTEST(TestTransformReduceDeviceDevice);
 void TestTransformReduceCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
   
   Vector data(3);
   data[0] = 1; data[1] = -2; data[2] = 3;

--- a/testing/backend/cuda/transform_scan.cu
+++ b/testing/backend/cuda/transform_scan.cu
@@ -95,9 +95,9 @@ DECLARE_UNITTEST(TestTransformScanDeviceDevice);
 void TestTransformScanCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
+  typedef Vector::value_type T;
 
-  typename Vector::iterator iter;
+  Vector::iterator iter;
 
   Vector input(5);
   Vector result(5);

--- a/testing/backend/cuda/uninitialized_copy.cu
+++ b/testing/backend/cuda/uninitialized_copy.cu
@@ -15,7 +15,6 @@ template<typename ExecutionPolicy>
 void TestUninitializedCopyDevice(ExecutionPolicy exec)
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
   
   Vector v1(5);
   v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;
@@ -48,7 +47,6 @@ DECLARE_UNITTEST(TestUninitializedCopyDeviceDevice);
 void TestUninitializedCopyCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
   
   Vector v1(5);
   v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;
@@ -85,7 +83,6 @@ template<typename ExecutionPolicy>
 void TestUninitializedCopyNDevice(ExecutionPolicy exec)
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
   
   Vector v1(5);
   v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;
@@ -118,7 +115,6 @@ DECLARE_UNITTEST(TestUninitializedCopyNDeviceDevice);
 void TestUninitializedCopyNCudaStreams()
 {
   typedef thrust::device_vector<int> Vector;
-  typedef typename Vector::value_type T;
   
   Vector v1(5);
   v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;

--- a/testing/backend/cuda/unique_by_key.cu
+++ b/testing/backend/cuda/unique_by_key.cu
@@ -132,7 +132,7 @@ void TestUniqueByKeyCudaStreams()
   Vector keys;
   Vector values;
   
-  typedef thrust::pair<typename Vector::iterator, typename Vector::iterator> iter_pair;
+  typedef thrust::pair<Vector::iterator, Vector::iterator> iter_pair;
   iter_pair new_last;
   
   // basic test
@@ -270,7 +270,7 @@ void TestUniqueCopyByKeyCudaStreams()
   Vector keys;
   Vector values;
 
-  typedef thrust::pair<typename Vector::iterator, typename Vector::iterator> iter_pair;
+  typedef thrust::pair<Vector::iterator, Vector::iterator> iter_pair;
   iter_pair new_last;
 
   // basic test

--- a/testing/binary_search.cu
+++ b/testing/binary_search.cu
@@ -14,8 +14,6 @@ __THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 template <class Vector>
 void TestScalarLowerBoundSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 0;
@@ -84,8 +82,6 @@ DECLARE_UNITTEST(TestScalarLowerBoundDispatchImplicit);
 template <class Vector>
 void TestScalarUpperBoundSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 0;
@@ -153,8 +149,6 @@ DECLARE_UNITTEST(TestScalarUpperBoundDispatchImplicit);
 template <class Vector>
 void TestScalarBinarySearchSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 0;
@@ -222,8 +216,6 @@ DECLARE_UNITTEST(TestScalarBinarySearchDispatchImplicit);
 template <class Vector>
 void TestScalarEqualRangeSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 0;

--- a/testing/binary_search_descending.cu
+++ b/testing/binary_search_descending.cu
@@ -39,8 +39,6 @@ DECLARE_VECTOR_UNITTEST(TestScalarLowerBoundDescendingSimple);
 template <class Vector>
 void TestScalarUpperBoundDescendingSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 8;
@@ -66,8 +64,6 @@ DECLARE_VECTOR_UNITTEST(TestScalarUpperBoundDescendingSimple);
 template <class Vector>
 void TestScalarBinarySearchDescendingSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 8;
@@ -93,8 +89,6 @@ DECLARE_VECTOR_UNITTEST(TestScalarBinarySearchDescendingSimple);
 template <class Vector>
 void TestScalarEqualRangeDescendingSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 8;

--- a/testing/binary_search_vector.cu
+++ b/testing/binary_search_vector.cu
@@ -23,8 +23,6 @@ struct vector_like
 template <class Vector>
 void TestVectorLowerBoundSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 0;
@@ -125,8 +123,6 @@ DECLARE_UNITTEST(TestVectorLowerBoundDispatchImplicit);
 template <class Vector>
 void TestVectorUpperBoundSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 0;
@@ -225,8 +221,6 @@ DECLARE_UNITTEST(TestVectorUpperBoundDispatchImplicit);
 template <class Vector>
 void TestVectorBinarySearchSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 0;

--- a/testing/binary_search_vector_descending.cu
+++ b/testing/binary_search_vector_descending.cu
@@ -59,8 +59,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorLowerBoundDescendingSimple);
 template <class Vector>
 void TestVectorUpperBoundDescendingSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
 
     vec[0] = 8;
@@ -97,8 +95,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorUpperBoundDescendingSimple);
 template <class Vector>
 void TestVectorBinarySearchDescendingSimple(void)
 {
-  typedef typename Vector::value_type T;
-
   Vector vec(5);
 
   vec[0] = 8;

--- a/testing/constant_iterator.cu
+++ b/testing/constant_iterator.cu
@@ -98,7 +98,6 @@ void TestConstantIteratorCopy(void)
 {
   using namespace thrust;
 
-  typedef typename Vector::value_type T;
   typedef constant_iterator<int> ConstIter;
 
   Vector result(4);

--- a/testing/copy.cu
+++ b/testing/copy.cu
@@ -133,8 +133,6 @@ DECLARE_VECTOR_UNITTEST(TestCopyMatchingTypes);
 template <class Vector>
 void TestCopyMixedTypes(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(5);
     v[0] = 0; v[1] = 1; v[2] = 2; v[3] = 3; v[4] = 4;
 

--- a/testing/copy_n.cu
+++ b/testing/copy_n.cu
@@ -96,8 +96,6 @@ DECLARE_VECTOR_UNITTEST(TestCopyNMatchingTypes);
 template <class Vector>
 void TestCopyNMixedTypes(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(5);
     v[0] = 0; v[1] = 1; v[2] = 2; v[3] = 3; v[4] = 4;
 

--- a/testing/count.cu
+++ b/testing/count.cu
@@ -5,8 +5,6 @@
 template <class Vector>
 void TestCountSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector data(5);
     data[0] = 1; data[1] = 1; data[2] = 0; data[3] = 0; data[4] = 1;
 
@@ -68,8 +66,6 @@ DECLARE_VARIABLE_UNITTEST(TestCountIf);
 template <typename Vector>
 void TestCountFromConstIteratorSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector data(5);
     data[0] = 1; data[1] = 1; data[2] = 0; data[3] = 0; data[4] = 1;
 

--- a/testing/device_ptr.cu
+++ b/testing/device_ptr.cu
@@ -4,8 +4,6 @@
 
 void TestDevicePointerManipulation(void)
 {
-    typedef int T;
-
     thrust::device_vector<int> data(5);
 
     thrust::device_ptr<int> begin(&data[0]);

--- a/testing/distance.cu
+++ b/testing/distance.cu
@@ -6,7 +6,6 @@
 template <typename Vector>
 void TestDistance(void)
 {
-    typedef typename Vector::value_type T;
     typedef typename Vector::iterator Iterator;
 
     Vector v(100);

--- a/testing/fill.cu
+++ b/testing/fill.cu
@@ -67,8 +67,6 @@ DECLARE_UNITTEST(TestFillDiscardIterator);
 template <class Vector>
 void TestFillMixedTypes(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(4);
 
     thrust::fill(v.begin(), v.end(), (long) 10);
@@ -191,8 +189,6 @@ DECLARE_UNITTEST(TestFillNDiscardIterator);
 template <class Vector>
 void TestFillNMixedTypes(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(4);
 
     typename Vector::iterator iter = thrust::fill_n(v.begin(), v.size(), (long) 10);

--- a/testing/find.cu
+++ b/testing/find.cu
@@ -39,8 +39,6 @@ struct less_than_value_pred
 template <class Vector>
 void TestFindSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector vec(5);
     vec[0] = 1;
     vec[1] = 2;

--- a/testing/functional_placeholders_bitwise.cu
+++ b/testing/functional_placeholders_bitwise.cu
@@ -28,7 +28,6 @@ template<typename Vector> \
     static const size_t num_samples = 10000; \
     const size_t zero = 0; \
     typedef typename Vector::value_type T; \
-    typedef typename rebind_vector<Vector,bool>::type bool_vector; \
     Vector lhs = unittest::random_samples<T>(num_samples); \
     Vector rhs = unittest::random_samples<T>(num_samples); \
     thrust::replace(rhs.begin(), rhs.end(), T(0), T(1)); \

--- a/testing/gather.cu
+++ b/testing/gather.cu
@@ -13,8 +13,6 @@ __THRUST_DISABLE_MSVC_POSSIBLE_LOSS_OF_DATA_WARNING_BEGIN
 template <class Vector>
 void TestGatherSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector map(5);  // gather indices
     Vector src(8);  // source vector
     Vector dst(5);  // destination vector
@@ -141,8 +139,6 @@ DECLARE_VARIABLE_UNITTEST(TestGatherToDiscardIterator);
 template <class Vector>
 void TestGatherIfSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector flg(5);  // predicate array
     Vector map(5);  // gather indices
     Vector src(8);  // source vector
@@ -315,8 +311,6 @@ DECLARE_VARIABLE_UNITTEST(TestGatherIfToDiscardIterator);
 template <typename Vector>
 void TestGatherCountingIterator(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector source(10);
     thrust::sequence(source.begin(), source.end(), 0);
 

--- a/testing/is_partitioned.cu
+++ b/testing/is_partitioned.cu
@@ -14,7 +14,6 @@ template<typename Vector>
 void TestIsPartitionedSimple(void)
 {
   typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
 
   Vector v(4);
   v[0] = 1; v[1] = 1; v[2] = 1; v[3] = 0;

--- a/testing/minmax_element.cu
+++ b/testing/minmax_element.cu
@@ -5,8 +5,6 @@
 template <class Vector>
 void TestMinMaxElementSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector data(6);
     data[0] = 3;
     data[1] = 5;

--- a/testing/mismatch.cu
+++ b/testing/mismatch.cu
@@ -5,8 +5,6 @@
 template <class Vector>
 void TestMismatchSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector a(4); Vector b(4);
     a[0] = 1; b[0] = 1;
     a[1] = 2; b[1] = 2;

--- a/testing/partition.cu
+++ b/testing/partition.cu
@@ -990,8 +990,6 @@ struct is_ordered
 template<typename Vector>
 void TestPartitionZipIterator(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector data1(5);
     Vector data2(5);
 
@@ -1029,8 +1027,6 @@ DECLARE_VECTOR_UNITTEST(TestPartitionZipIterator);
 template<typename Vector>
 void TestPartitionStencilZipIterator(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector data(5);
     data[0] = 1;
     data[1] = 0;
@@ -1072,8 +1068,6 @@ DECLARE_VECTOR_UNITTEST(TestPartitionStencilZipIterator);
 template<typename Vector>
 void TestStablePartitionZipIterator(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector data1(5);
     Vector data2(5);
 
@@ -1111,8 +1105,6 @@ DECLARE_VECTOR_UNITTEST(TestStablePartitionZipIterator);
 template<typename Vector>
 void TestStablePartitionStencilZipIterator(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector data(5);
     data[0] = 1;
     data[1] = 0;

--- a/testing/permutation_iterator.cu
+++ b/testing/permutation_iterator.cu
@@ -118,8 +118,6 @@ DECLARE_VECTOR_UNITTEST(TestPermutationIteratorScatter);
 template <class Vector>
 void TestMakePermutationIterator(void)
 {
-    typedef typename Vector::iterator Iterator;
-
     Vector source(8);
     Vector indices(4);
     Vector output(4, 10);
@@ -282,7 +280,6 @@ template <typename Vector>
 void TestPermutationIteratorWithCountingIterator(void)
 {
   typedef typename Vector::value_type T;
-  typedef typename Vector::iterator Iterator;
   
   typename thrust::counting_iterator<T> input(0), index(0);
 

--- a/testing/reduce_by_key.cu
+++ b/testing/reduce_by_key.cu
@@ -172,14 +172,6 @@ struct TestReduceByKeyToDiscardIterator
         thrust::device_vector<K> d_keys_output(n);
         thrust::device_vector<V> d_vals_output(n);
 
-        typedef typename thrust::host_vector<K>::iterator   HostKeyIterator;
-        typedef typename thrust::host_vector<V>::iterator   HostValIterator;
-        typedef typename thrust::device_vector<K>::iterator DeviceKeyIterator;
-        typedef typename thrust::device_vector<V>::iterator DeviceValIterator;
-
-        typedef typename thrust::pair<HostKeyIterator,  HostValIterator>   HostIteratorPair;
-        typedef typename thrust::pair<DeviceKeyIterator,DeviceValIterator> DeviceIteratorPair;
-
         thrust::host_vector<K> unique_keys = h_keys;
         unique_keys.erase(thrust::unique(unique_keys.begin(), unique_keys.end()), unique_keys.end());
 

--- a/testing/scan_by_key.cu
+++ b/testing/scan_by_key.cu
@@ -323,8 +323,6 @@ DECLARE_VECTOR_UNITTEST(TestInclusiveScanByKeyTransformIterator);
 template <typename Vector>
 void TestScanByKeyReusedKeys(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector keys(7);
     Vector vals(7);
 
@@ -544,7 +542,6 @@ DECLARE_UNITTEST(TestScanByKeyMixedTypes);
 
 void TestScanByKeyLargeInput()
 {
-    typedef int T;
     const unsigned int N = 1 << 20;
 
     thrust::host_vector<unsigned int> vals_sizes = unittest::random_integers<unsigned int>(10);

--- a/testing/scatter.cu
+++ b/testing/scatter.cu
@@ -10,8 +10,6 @@
 template <class Vector>
 void TestScatterSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector map(5);  // scatter indices
     Vector src(5);  // source vector
     Vector dst(8);  // destination vector
@@ -141,8 +139,6 @@ DECLARE_VARIABLE_UNITTEST(TestScatterToDiscardIterator);
 template <class Vector>
 void TestScatterIfSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector flg(5);  // predicate array
     Vector map(5);  // scatter indices
     Vector src(5);  // source vector
@@ -284,8 +280,6 @@ DECLARE_VARIABLE_UNITTEST(TestScatterIfToDiscardIterator);
 template <typename Vector>
 void TestScatterCountingIterator(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector source(10);
     thrust::sequence(source.begin(), source.end(), 0);
 
@@ -324,8 +318,6 @@ DECLARE_VECTOR_UNITTEST(TestScatterCountingIterator);
 template <typename Vector>
 void TestScatterIfCountingIterator(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector source(10);
     thrust::sequence(source.begin(), source.end(), 0);
 

--- a/testing/sequence.cu
+++ b/testing/sequence.cu
@@ -43,8 +43,6 @@ DECLARE_UNITTEST(TestSequenceDispatchImplicit);
 template <class Vector>
 void TestSequenceSimple(void)
 {
-    typedef typename Vector::value_type T;
-    
     Vector v(5);
 
     thrust::sequence(v.begin(), v.end());

--- a/testing/sort.cu
+++ b/testing/sort.cu
@@ -64,8 +64,6 @@ void InitializeSimpleKeySortTest(Vector& unsorted_keys, Vector& sorted_keys)
 template <class Vector>
 void TestSortSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector unsorted_keys;
     Vector   sorted_keys;
 

--- a/testing/swap_ranges.cu
+++ b/testing/swap_ranges.cu
@@ -55,8 +55,6 @@ DECLARE_UNITTEST(TestSwapRangesDispatchImplicit);
 template <class Vector>
 void TestSwapRangesSimple(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v1(5);
     v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;
 

--- a/testing/transform_output_iterator.cu
+++ b/testing/transform_output_iterator.cu
@@ -43,7 +43,6 @@ void TestMakeTransformOutputIterator(void)
     typedef typename Vector::value_type T;
 
     typedef thrust::negate<T> UnaryFunction;
-    typedef typename Vector::iterator Iterator;
 
     Vector input(4);
     Vector output(4);

--- a/testing/uninitialized_copy.cu
+++ b/testing/uninitialized_copy.cu
@@ -103,8 +103,6 @@ DECLARE_UNITTEST(TestUninitializedCopyNDispatchImplicit);
 template <class Vector>
 void TestUninitializedCopySimplePOD(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v1(5);
     v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;
 
@@ -123,8 +121,6 @@ DECLARE_VECTOR_UNITTEST(TestUninitializedCopySimplePOD);
 template<typename Vector>
 void TestUninitializedCopyNSimplePOD(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v1(5);
     v1[0] = 0; v1[1] = 1; v1[2] = 2; v1[3] = 3; v1[4] = 4;
 

--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -38,8 +38,6 @@ DECLARE_UNITTEST(TestVectorBool);
 template <class Vector>
 void TestVectorFrontBack(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(3);
     v[0] = 0; v[1] = 1; v[2] = 2;
 
@@ -52,8 +50,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorFrontBack);
 template <class Vector>
 void TestVectorData(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(3);
     v[0] = 0; v[1] = 1; v[2] = 2;
 
@@ -79,8 +75,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorData);
 template <class Vector>
 void TestVectorElementAssignment(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(3);
 
     v[0] = 0; v[1] = 1; v[2] = 2;
@@ -344,8 +338,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorWithInitialValue);
 template <class Vector>
 void TestVectorSwap(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(3);
     v[0] = 0; v[1] = 1; v[2] = 2;
 
@@ -364,8 +356,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorSwap);
 template <class Vector>
 void TestVectorErasePosition(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(5);
     v[0] = 0; v[1] = 1; v[2] = 2; v[3] = 3; v[4] = 4;
 
@@ -405,8 +395,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorErasePosition);
 template <class Vector>
 void TestVectorEraseRange(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v(6);
     v[0] = 0; v[1] = 1; v[2] = 2; v[3] = 3; v[4] = 4; v[5] = 5;
 
@@ -564,8 +552,6 @@ DECLARE_UNITTEST(TestVectorInequality);
 template <class Vector>
 void TestVectorResizing(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v;
 
     v.resize(3);
@@ -622,8 +608,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorResizing);
 template <class Vector>
 void TestVectorReserving(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v;
 
     v.reserve(3);
@@ -655,8 +639,6 @@ DECLARE_VECTOR_UNITTEST(TestVectorReserving)
 template <class Vector>
 void TestVectorShrinkToFit(void)
 {
-    typedef typename Vector::value_type T;
-
     Vector v;
 
     v.reserve(200);
@@ -735,7 +717,6 @@ template <typename Vector>
 void TestVectorReversed(void)
 {
   Vector v(3);
-  typedef typename Vector::value_type T;
   v[0] = 0; v[1] = 1; v[2] = 2;
 
   ASSERT_EQUAL(3, v.rend() - v.rbegin());

--- a/testing/zip_iterator.cu
+++ b/testing/zip_iterator.cu
@@ -148,6 +148,7 @@ template <typename T>
   {
     using namespace thrust;
 
+#if 0
     // test host types
     typedef typename host_vector<T>::iterator          Iterator1;
     typedef typename host_vector<T>::const_iterator    Iterator2;
@@ -155,10 +156,12 @@ template <typename T>
     typedef zip_iterator<IteratorTuple1> ZipIterator1;
 
     typedef typename iterator_traversal<ZipIterator1>::type zip_iterator_traversal_type1;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_traversal_type1, random_access_traversal_tag>::value) );
 
 
+#if 0
     // test device types
     typedef typename device_vector<T>::iterator        Iterator3;
     typedef typename device_vector<T>::const_iterator  Iterator4;
@@ -166,6 +169,7 @@ template <typename T>
     typedef zip_iterator<IteratorTuple2> ZipIterator2;
 
     typedef typename iterator_traversal<ZipIterator2>::type zip_iterator_traversal_type2;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_traversal_type2, thrust::random_access_traversal_tag>::value) );
   } // end operator()()
@@ -182,6 +186,7 @@ template <typename T>
 
     // XXX these assertions complain about undefined references to integral_constant<...>::value
 
+#if 0
     // test host types
     typedef typename host_vector<T>::iterator          Iterator1;
     typedef typename host_vector<T>::const_iterator    Iterator2;
@@ -189,10 +194,12 @@ template <typename T>
     typedef zip_iterator<IteratorTuple1> ZipIterator1;
 
     typedef typename iterator_system<ZipIterator1>::type zip_iterator_system_type1;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_same<zip_iterator_system_type1, experimental::space::host>::value) );
 
 
+#if 0
     // test device types
     typedef typename device_vector<T>::iterator        Iterator3;
     typedef typename device_vector<T>::const_iterator  Iterator4;
@@ -200,10 +207,12 @@ template <typename T>
     typedef zip_iterator<IteratorTuple1> ZipIterator2;
 
     typedef typename iterator_system<ZipIterator2>::type zip_iterator_system_type2;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_system_type2, experimental::space::device>::value) );
 
 
+#if 0
     // test any
     typedef counting_iterator<T>         Iterator5;
     typedef counting_iterator<const T>   Iterator6;
@@ -211,42 +220,51 @@ template <typename T>
     typedef zip_iterator<IteratorTuple3> ZipIterator3;
 
     typedef typename iterator_system<ZipIterator3>::type zip_iterator_system_type3;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_system_type3, thrust::experimental::space::any>::value) );
 
     
+#if 0
     // test host/any
     typedef tuple<Iterator1, Iterator5>                IteratorTuple4;
     typedef zip_iterator<IteratorTuple4> ZipIterator4;
 
     typedef typename iterator_system<ZipIterator4>::type zip_iterator_system_type4;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_system_type4, thrust::host_system_tag>::value) );
 
 
+#if 0
     // test any/host
     typedef tuple<Iterator5, Iterator1>                IteratorTuple5;
     typedef zip_iterator<IteratorTuple5> ZipIterator5;
 
     typedef typename iterator_system<ZipIterator5>::type zip_iterator_system_type5;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_system_type5, thrust::host_system_tag>::value) );
 
 
+#if 0
     // test device/any
     typedef tuple<Iterator3, Iterator5>                IteratorTuple6;
     typedef zip_iterator<IteratorTuple6> ZipIterator6;
 
     typedef typename iterator_system<ZipIterator6>::type zip_iterator_system_type6;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_system_type6, thrust::device_system_tag>::value) );
 
 
+#if 0
     // test any/device
     typedef tuple<Iterator5, Iterator3>                IteratorTuple7;
     typedef zip_iterator<IteratorTuple7> ZipIterator7;
 
     typedef typename iterator_system<ZipIterator7>::type zip_iterator_system_type7;
+#endif
 
     //ASSERT_EQUAL(true, (detail::is_convertible<zip_iterator_system_type7, thrust::device_system_tag>::value) );
   } // end operator()()

--- a/thrust/detail/static_assert.h
+++ b/thrust/detail/static_assert.h
@@ -70,6 +70,12 @@ template<typename, bool x>
    typedef ::thrust::detail::static_assert_test<\
       sizeof(::thrust::detail::STATIC_ASSERTION_FAILURE< (bool)( B ) >)>\
          THRUST_JOIN(thrust_static_assert_typedef_, __LINE__) __attribute__((unused))
+#elif (THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG)
+  // clang will complain about this typedef being unused unless we annotate it as such
+#  define THRUST_STATIC_ASSERT( B ) \
+   typedef ::thrust::detail::static_assert_test<\
+      sizeof(::thrust::detail::STATIC_ASSERTION_FAILURE< (bool)( B ) >)>\
+         THRUST_JOIN(thrust_static_assert_typedef_, __LINE__) __attribute__((unused))
 #else
 #  define THRUST_STATIC_ASSERT( B ) \
    typedef ::thrust::detail::static_assert_test<\

--- a/thrust/iterator/detail/transform_output_iterator.inl
+++ b/thrust/iterator/detail/transform_output_iterator.inl
@@ -33,7 +33,7 @@ template <typename UnaryFunction, typename OutputIterator>
 {
   public:
     __host__ __device__
-    transform_output_iterator_proxy(const OutputIterator& out, UnaryFunction fun) : fun(fun), out(out)
+    transform_output_iterator_proxy(const OutputIterator& out, UnaryFunction fun) : out(out), fun(fun)
     {
     }
 

--- a/thrust/system/cuda/detail/bulk/algorithm/scan.hpp
+++ b/thrust/system/cuda/detail/bulk/algorithm/scan.hpp
@@ -363,8 +363,6 @@ __device__ void scan_with_buffer(bulk::concurrent_group<bulk::agent<grainsize>,g
 
   typedef typename bulk::concurrent_group<bulk::agent<grainsize>,groupsize>::size_type size_type;
 
-  size_type tid = g.this_exec.index();
-
   const size_type elements_per_group = groupsize * grainsize;
 
   for(; first < last; first += elements_per_group, result += elements_per_group)

--- a/thrust/system/cuda/detail/cub/block/block_exchange.cuh
+++ b/thrust/system/cuda/detail/cub/block/block_exchange.cuh
@@ -705,8 +705,8 @@ public:
     :
         temp_storage(temp_storage.Alias()),
         linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z)),
-        warp_id((WARPS == 1) ? 0 : linear_tid / WARP_THREADS),
         lane_id(LaneId()),
+        warp_id((WARPS == 1) ? 0 : linear_tid / WARP_THREADS),
         warp_offset(warp_id * WARP_TIME_SLICED_ITEMS)
     {}
 

--- a/thrust/system/cuda/detail/cub/block_sweep/block_radix_sort_downsweep.cuh
+++ b/thrust/system/cuda/detail/cub/block_sweep/block_radix_sort_downsweep.cuh
@@ -674,8 +674,8 @@ struct BlockRadixSortDownsweep
     :
         temp_storage(temp_storage.Alias()),
         d_keys_in(reinterpret_cast<UnsignedBits*>(d_keys_in)),
-        d_keys_out(reinterpret_cast<UnsignedBits*>(d_keys_out)),
         d_values_in(d_values_in),
+        d_keys_out(reinterpret_cast<UnsignedBits*>(d_keys_out)),
         d_values_out(d_values_out),
         current_bit(current_bit),
         num_bits(num_bits)

--- a/thrust/system/cuda/detail/cub/device/device_reduce.cuh
+++ b/thrust/system/cuda/detail/cub/device/device_reduce.cuh
@@ -653,8 +653,10 @@ struct DeviceReduce
         bool                        debug_synchronous  = false)     ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         typedef int                 Offset;         // Signed integer type for global offsets
+#if (THRUST_HOST_COMPILER != THRUST_HOST_COMPILER_CLANG)
         typedef NullType*           FlagIterator;   // Flag iterator type (not used)
         typedef NullType            SelectOp;       // Selection op (not used)
+#endif
         typedef Equality            EqualityOp;     // Default == operator
 
         return DeviceReduceByKeyDispatch<KeysInputIterator, UniqueOutputIterator, ValuesInputIterator, AggregatesOutputIterator, NumRunsOutputIterator, EqualityOp, ReductionOp, Offset>::Dispatch(

--- a/thrust/system/cuda/detail/cub/util_allocator.cuh
+++ b/thrust/system/cuda/detail/cub/util_allocator.cuh
@@ -169,22 +169,22 @@ struct CachingDeviceAllocator
 
         // Constructor
         BlockDescriptor(void *d_ptr, int device) :
-            d_ptr(d_ptr),
-            bytes(0),
-            bin(0),
             device(device),
+            d_ptr(d_ptr),
             associated_stream(0),
-            ready_event(0)
+            ready_event(0),
+            bytes(0),
+            bin(0)
         {}
 
         // Constructor
         BlockDescriptor(size_t bytes, unsigned int bin, int device, cudaStream_t associated_stream) :
-            d_ptr(NULL),
-            bytes(bytes),
-            bin(bin),
             device(device),
+            d_ptr(NULL),
             associated_stream(associated_stream),
-            ready_event(0)
+            ready_event(0),
+            bytes(bytes),
+            bin(bin)
         {}
 
         // Comparison functor for comparing device pointers
@@ -263,18 +263,18 @@ struct CachingDeviceAllocator
         size_t          max_cached_bytes,       ///< Maximum aggregate cached bytes per device
         bool            skip_cleanup = false)   ///< Whether or not to skip a call to \p FreeAllCached() when the destructor is called.  (Useful for preventing warnings when the allocator is declared at file/static/global scope: by the time the destructor is called on program exit, the CUDA runtime may have already shut down and freed all allocations.)
     :
-    #if (CUB_PTX_ARCH == 0)   // Only define STL container members in host code
-            cached_blocks(BlockDescriptor::SizeCompare),
-            live_blocks(BlockDescriptor::PtrCompare),
-    #endif
-            debug(false),
             spin_lock(0),
             bin_growth(bin_growth),
             min_bin(min_bin),
             max_bin(max_bin),
             min_bin_bytes(IntPow(bin_growth, min_bin)),
             max_bin_bytes(IntPow(bin_growth, max_bin)),
-            max_cached_bytes(max_cached_bytes)
+            max_cached_bytes(max_cached_bytes),
+            debug(false)
+    #if (CUB_PTX_ARCH == 0)   // Only define STL container members in host code
+            ,cached_blocks(BlockDescriptor::SizeCompare),
+            live_blocks(BlockDescriptor::PtrCompare)
+    #endif
     {}
 
 
@@ -294,19 +294,19 @@ struct CachingDeviceAllocator
     CachingDeviceAllocator(
         bool skip_cleanup = false)  ///< Whether or not to skip a call to \p FreeAllCached() when the destructor is called.  (Useful for preventing warnings when the allocator is declared at file/static/global scope: by the time the destructor is called on program exit, the CUDA runtime may have already shut down and freed all allocations.)
     :
-    #if (CUB_PTX_ARCH == 0)   // Only define STL container members in host code
-        cached_blocks(BlockDescriptor::SizeCompare),
-        live_blocks(BlockDescriptor::PtrCompare),
-    #endif
-        skip_cleanup(skip_cleanup),
-        debug(false),
         spin_lock(0),
         bin_growth(8),
         min_bin(3),
         max_bin(7),
         min_bin_bytes(IntPow(bin_growth, min_bin)),
         max_bin_bytes(IntPow(bin_growth, max_bin)),
-        max_cached_bytes((max_bin_bytes * 3) - 1)
+        max_cached_bytes((max_bin_bytes * 3) - 1),
+        debug(false),
+        skip_cleanup(skip_cleanup)
+    #if (CUB_PTX_ARCH == 0)   // Only define STL container members in host code
+        ,cached_blocks(BlockDescriptor::SizeCompare),
+        live_blocks(BlockDescriptor::PtrCompare)
+    #endif
     {}
 
 

--- a/thrust/system/cuda/detail/detail/launch_closure.inl
+++ b/thrust/system/cuda/detail/detail/launch_closure.inl
@@ -86,10 +86,12 @@ template<typename Closure,
   static void launch(execution_policy<DerivedPolicy> &exec, Closure f, Size1 num_blocks, Size2 block_size, Size3 smem_size)
   {
     // this ensures that the kernel gets instantiated identically for all values of __CUDA_ARCH__
-    launch_function_t kernel = get_launch_function();
+    get_launch_function();
 
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_NVCC
 #if __BULK_HAS_CUDART__
+    launch_function_t kernel = get_launch_function();
+
     if(num_blocks > 0)
     {
 #ifndef __CUDA_ARCH__

--- a/thrust/system/cuda/detail/detail/set_operation.inl
+++ b/thrust/system/cuda/detail/detail/set_operation.inl
@@ -302,8 +302,8 @@ inline __device__
       // load the input into __shared__ storage
       __shared__ uninitialized_array<value_type, block_size * work_per_thread> s_input;
   
-      value_type *s_input_end1 = thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
-      value_type *s_input_end2 = thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
+      value_type *s_input_end1    =    thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
+      /* value_type *s_input_end2 = */ thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
   
       result += block::bounded_count_set_operation_n<block_size,work_per_thread>(ctx,
                                                                                  s_input.begin(), subpartition_size.first,
@@ -361,8 +361,8 @@ OutputIterator set_operation(statically_blocked_thread_array<block_size> &ctx,
       // load the input into __shared__ storage
       __shared__ uninitialized_array<value_type, block_size * work_per_thread> s_input;
   
-      value_type *s_input_end1 = thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
-      value_type *s_input_end2 = thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
+      value_type *s_input_end1    =    thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
+      /* value_type *s_input_end2 = */ thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
   
       result = block::bounded_set_operation_n<block_size,work_per_thread>(ctx,
                                                                           s_input.begin(), subpartition_size.first,

--- a/thrust/system/cuda/detail/detail/set_operation.inl
+++ b/thrust/system/cuda/detail/detail/set_operation.inl
@@ -302,8 +302,8 @@ inline __device__
       // load the input into __shared__ storage
       __shared__ uninitialized_array<value_type, block_size * work_per_thread> s_input;
   
-      value_type *s_input_end1    =    thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
-      /* value_type *s_input_end2 = */ thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
+      value_type *s_input_end1 = thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
+      thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
   
       result += block::bounded_count_set_operation_n<block_size,work_per_thread>(ctx,
                                                                                  s_input.begin(), subpartition_size.first,
@@ -361,8 +361,8 @@ OutputIterator set_operation(statically_blocked_thread_array<block_size> &ctx,
       // load the input into __shared__ storage
       __shared__ uninitialized_array<value_type, block_size * work_per_thread> s_input;
   
-      value_type *s_input_end1    =    thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
-      /* value_type *s_input_end2 = */ thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
+      value_type *s_input_end1 = thrust::system::cuda::detail::block::copy_n(ctx, first1, subpartition_size.first,  s_input.begin());
+      thrust::system::cuda::detail::block::copy_n(ctx, first2, subpartition_size.second, s_input_end1);
   
       result = block::bounded_set_operation_n<block_size,work_per_thread>(ctx,
                                                                           s_input.begin(), subpartition_size.first,

--- a/thrust/system/detail/sequential/sort.inl
+++ b/thrust/system/detail/sequential/sort.inl
@@ -160,10 +160,10 @@ void stable_sort(sequential::execution_policy<DerivedPolicy> &exec,
                  RandomAccessIterator last,
                  StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_traits<RandomAccessIterator>::value_type KeyType;
 
   // the compilation time of stable_primitive_sort is too expensive to use within a single CUDA thread
 #ifndef __CUDA_ARCH__
+  typedef typename thrust::iterator_traits<RandomAccessIterator>::value_type KeyType;
   sort_detail::use_primitive_sort<KeyType,StrictWeakOrdering> use_primitive_sort;
 #else
   thrust::detail::false_type use_primitive_sort;
@@ -184,10 +184,10 @@ void stable_sort_by_key(sequential::execution_policy<DerivedPolicy> &exec,
                         RandomAccessIterator2 first2,
                         StrictWeakOrdering comp)
 {
-  typedef typename thrust::iterator_traits<RandomAccessIterator1>::value_type KeyType;
 
   // the compilation time of stable_primitive_sort_by_key is too expensive to use within a single CUDA thread
 #ifndef __CUDA_ARCH__
+  typedef typename thrust::iterator_traits<RandomAccessIterator1>::value_type KeyType;
   sort_detail::use_primitive_sort<KeyType,StrictWeakOrdering> use_primitive_sort;
 #else
   thrust::detail::false_type use_primitive_sort;


### PR DESCRIPTION
No warnings are generated when thrust examples & tests are compiled with clang top of the tree. No additional regressions were introduced: what used to pass before, passes now, and same for fails.