### PR TITLE
Mark functions that take the address of a __global__ function as host…

### DIFF
--- a/thrust/system/cuda/detail/bulk/detail/cuda_launcher/triple_chevron_launcher.hpp
+++ b/thrust/system/cuda/detail/bulk/detail/cuda_launcher/triple_chevron_launcher.hpp
@@ -74,7 +74,13 @@ struct triple_chevron_launcher_base<block_size,Function,true>
   __host__ __device__
   static global_function_pointer_t global_function_pointer()
   {
+    // Don't try to take the address of launch_by_value from the device side if
+    // we don't support launching kernels from __device__ functions.
+#if !defined(__CUDA_ARCH__) || defined(__CUDACC_RDC__)
     return launch_by_value<block_size,Function>;
+#else
+    return NULL;
+#endif
   }
 };
 
@@ -98,7 +104,13 @@ struct triple_chevron_launcher_base<block_size,Function,false>
   __host__ __device__
   static global_function_pointer_t global_function_pointer()
   {
+    // Don't try to take the address of launch_by_pointer from the device side
+    // if we don't support launching kernels from __device__ functions.
+#if !defined(__CUDA_ARCH__) || defined(__CUDACC_RDC__)
     return launch_by_pointer<block_size,Function>;
+#else
+    return NULL;
+#endif
   }
 };
 

--- a/thrust/system/cuda/detail/detail/launch_closure.inl
+++ b/thrust/system/cuda/detail/detail/launch_closure.inl
@@ -78,7 +78,13 @@ template<typename Closure,
   __host__ __device__
   static launch_function_t get_launch_function()
   {
+    // Don't try to take the address of launch_closure_by_value from the device
+    // side if we don't support launching kernels from __device__ functions.
+#if !defined(__CUDA_ARCH__) || defined(__CUDACC_RDC__)
     return launch_closure_by_value<Closure>;
+#else
+    return NULL;
+#endif
   }
 
   template<typename DerivedPolicy, typename Size1, typename Size2, typename Size3>
@@ -119,7 +125,14 @@ template<typename Closure>
   __host__ __device__
   static launch_function_t get_launch_function(void)
   {
+    // Don't try to take the address of launch_closure_by_pointer from the
+    // device side if we don't support launching kernels from __device__
+    // functions.
+#if !defined(__CUDA_ARCH__) || defined(__CUDACC_RDC__)
     return launch_closure_by_pointer<Closure>;
+#else
+    return NULL;
+#endif
   }
 
   template<typename DerivedPolicy, typename Size1, typename Size2, typename Size3>


### PR DESCRIPTION
…-only.

clang is about to get pickier about disallowing references to things
from host+device code when it won't work on either host or device.

clang doesn't currently support launching kernels from the device side,
thus these `__host__ __device__` functions that take a function pointer to
`__global__` functions are no good.

It doesn't look like Thrust tries to use nested kernels, so the
`__device__` attribute appears unnecessary here.  But if you like we could
make these functions `__host__ __device__` for compilers other than clang.