### PR TITLE
fix #833

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@ Other Enhancements
     for host_vector,device_vector,cpp::vector,cuda::vector,omp::vector and tbb::vector.
 
 Bug Fixes
-    TODO
+    calculating sin(complex<double>) no longer has precision loss to float
 
 Known Issues
     TODO

--- a/thrust/detail/complex/csinh.h
+++ b/thrust/detail/complex/csinh.h
@@ -58,7 +58,7 @@ namespace complex{
 using thrust::complex;
 
 __host__ __device__ inline
-complex<float> csinh(const complex<double>& z){
+complex<double> csinh(const complex<double>& z){
   double x, y, h;
   uint32_t hx, hy, ix, iy, lx, ly;
   const double huge = 8.98846567431157953864652595395e+307; // 0x1p1023;


### PR DESCRIPTION
return `complex<double>` instead of `complex<float>` when calculating `sin(complex<double>)`