### PR TITLE
Revert "Mark functions that take the address of a __global__ function as host…"

### DIFF
--- a/thrust/system/cuda/detail/bulk/detail/cuda_launcher/triple_chevron_launcher.hpp
+++ b/thrust/system/cuda/detail/bulk/detail/cuda_launcher/triple_chevron_launcher.hpp
@@ -74,13 +74,7 @@ struct triple_chevron_launcher_base<block_size,Function,true>
   __host__ __device__
   static global_function_pointer_t global_function_pointer()
   {
-    // Don't try to take the address of launch_by_value from the device side if
-    // we don't support launching kernels from __device__ functions.
-#if !defined(__CUDA_ARCH__) || (defined(__CUDACC_RDC__) && __CUDA_ARCH__ >= 350)
     return launch_by_value<block_size,Function>;
-#else
-    return NULL;
-#endif
   }
 };
 
@@ -104,13 +98,7 @@ struct triple_chevron_launcher_base<block_size,Function,false>
   __host__ __device__
   static global_function_pointer_t global_function_pointer()
   {
-    // Don't try to take the address of launch_by_pointer from the device side
-    // if we don't support launching kernels from __device__ functions.
-#if !defined(__CUDA_ARCH__) || (defined(__CUDACC_RDC__) && __CUDA_ARCH__ >= 350)
     return launch_by_pointer<block_size,Function>;
-#else
-    return NULL;
-#endif
   }
 };
 

--- a/thrust/system/cuda/detail/detail/launch_closure.inl
+++ b/thrust/system/cuda/detail/detail/launch_closure.inl
@@ -78,13 +78,7 @@ template<typename Closure,
   __host__ __device__
   static launch_function_t get_launch_function()
   {
-    // Don't try to take the address of launch_closure_by_value from the device
-    // side if we don't support launching kernels from __device__ functions.
-#if !defined(__CUDA_ARCH__) || (defined(__CUDACC_RDC__) && __CUDA_ARCH__ >= 350)
     return launch_closure_by_value<Closure>;
-#else
-    return NULL;
-#endif
   }
 
   template<typename DerivedPolicy, typename Size1, typename Size2, typename Size3>
@@ -125,14 +119,7 @@ template<typename Closure>
   __host__ __device__
   static launch_function_t get_launch_function(void)
   {
-    // Don't try to take the address of launch_closure_by_pointer from the
-    // device side if we don't support launching kernels from __device__
-    // functions.
-#if !defined(__CUDA_ARCH__) || (defined(__CUDACC_RDC__) && __CUDA_ARCH__ >= 350)
     return launch_closure_by_pointer<Closure>;
-#else
-    return NULL;
-#endif
   }
 
   template<typename DerivedPolicy, typename Size1, typename Size2, typename Size3>


### PR DESCRIPTION
Reverts thrust/thrust#835 due to bad interaction with `nvcc` 7.5.