### PR TITLE
Use old-style check for clang

### DIFF
--- a/thrust/system/cuda/detail/bulk/detail/cuda_launcher/triple_chevron_launcher.hpp
+++ b/thrust/system/cuda/detail/bulk/detail/cuda_launcher/triple_chevron_launcher.hpp
@@ -71,7 +71,7 @@ struct triple_chevron_launcher_base<block_size,Function,true>
 {
   typedef void (*global_function_pointer_t)(Function);
 
-#if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_CLANG
+#if defined(__CUDA__) && defined(__clang__)
   __host__
   static global_function_pointer_t global_function_pointer()
   {
@@ -111,7 +111,7 @@ struct triple_chevron_launcher_base<block_size,Function,false>
 {
   typedef void (*global_function_pointer_t)(const Function*);
 
-#if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_CLANG
+#if defined (__CUDA__) && defined(__clang__)
   __host__
   static global_function_pointer_t global_function_pointer()
   {
@@ -241,4 +241,3 @@ class triple_chevron_launcher<block_size_,Function,false> : protected triple_che
 } // end detail
 } // end bul
 BULK_NAMESPACE_SUFFIX
-

--- a/thrust/system/cuda/detail/detail/launch_closure.inl
+++ b/thrust/system/cuda/detail/detail/launch_closure.inl
@@ -75,7 +75,7 @@ template<typename Closure,
 {
   typedef void (*launch_function_t)(Closure); 
  
-#if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_CLANG
+#if defined(__CUDA__) && defined(__clang__)
   __host__
   static launch_function_t get_launch_function()
   {
@@ -132,7 +132,7 @@ template<typename Closure>
 {
   typedef void (*launch_function_t)(const Closure *); 
  
-#if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_CLANG
+#if defined(__CUDA__) && defined(__clang__)
   __host__
   static launch_function_t get_launch_function(void)
   {


### PR DESCRIPTION
.. until the rest of clang sources are ready for THRUST_DEVICE_COMPILER_CLANG