### PR TITLE
Issue 855

### DIFF
--- a/testing/device_reference.cu
+++ b/testing/device_reference.cu
@@ -206,3 +206,26 @@ void TestDeviceReferenceManipulation(void)
 }
 DECLARE_UNITTEST(TestDeviceReferenceManipulation);
 
+void TestDeviceReferenceSwap(void)
+{
+  typedef int T;
+
+  thrust::device_vector<T> v(2);
+  thrust::device_reference<T> ref1 = v.front();
+  thrust::device_reference<T> ref2 = v.back();
+
+  ref1 = 7;
+  ref2 = 13;
+
+  // test thrust::swap()
+  thrust::swap(ref1, ref2);
+  ASSERT_EQUAL(13, ref1);
+  ASSERT_EQUAL(7, ref2);
+
+  // test .swap()
+  ref1.swap(ref2);
+  ASSERT_EQUAL(7, ref1);
+  ASSERT_EQUAL(13, ref2);
+}
+DECLARE_UNITTEST(TestDeviceReferenceSwap);
+

--- a/thrust/system/cuda/detail/iter_swap.h
+++ b/thrust/system/cuda/detail/iter_swap.h
@@ -18,6 +18,7 @@
 
 #include <thrust/detail/config.h>
 #include <thrust/detail/raw_pointer_cast.h>
+#include <thrust/system/cuda/detail/execution_policy.h>
 #include <thrust/swap.h>
 
 namespace thrust
@@ -30,9 +31,9 @@ namespace detail
 {
 
 
-template<typename Pointer1, typename Pointer2>
+template<typename DerivedPolicy, typename Pointer1, typename Pointer2>
 inline __host__ __device__
-void iter_swap(tag, Pointer1 a, Pointer2 b)
+void iter_swap(thrust::cuda::execution_policy<DerivedPolicy> &, Pointer1 a, Pointer2 b)
 {
   // XXX war nvbugs/881631
   struct war_nvbugs_881631
@@ -51,7 +52,7 @@ void iter_swap(tag, Pointer1 a, Pointer2 b)
   };
 
 #ifndef __CUDA_ARCH__
-  return war_nvbugs_881631::host_path(a,b);
+  return war_nvbugs_881631::host_path(a, b);
 #else
   return war_nvbugs_881631::device_path(a,b);
 #endif // __CUDA_ARCH__

--- a/thrust/system/cuda/detail/iter_swap.h
+++ b/thrust/system/cuda/detail/iter_swap.h
@@ -52,7 +52,7 @@ void iter_swap(thrust::cuda::execution_policy<DerivedPolicy> &, Pointer1 a, Poin
   };
 
 #ifndef __CUDA_ARCH__
-  return war_nvbugs_881631::host_path(a, b);
+  return war_nvbugs_881631::host_path(a,b);
 #else
   return war_nvbugs_881631::device_path(a,b);
 #endif // __CUDA_ARCH__

--- a/thrust/system/detail/generic/memory.h
+++ b/thrust/system/detail/generic/memory.h
@@ -59,9 +59,9 @@ template<typename DerivedPolicy, typename Pointer>
 __host__ __device__
 void get_value(thrust::execution_policy<DerivedPolicy> &, Pointer);
 
-template<typename Pointer1, typename Pointer2>
+template<typename DerivedPolicy, typename Pointer1, typename Pointer2>
 __host__ __device__
-void iter_swap(tag, Pointer1, Pointer2);
+void iter_swap(thrust::execution_policy<DerivedPolicy>&, Pointer1, Pointer2);
 
 } // end generic
 } // end detail

--- a/thrust/system/detail/generic/memory.inl
+++ b/thrust/system/detail/generic/memory.inl
@@ -79,9 +79,9 @@ void get_value(thrust::execution_policy<DerivedPolicy> &, Pointer)
 }
 
 
-template<typename Pointer1, typename Pointer2>
+template<typename DerivedPolicy, typename Pointer1, typename Pointer2>
 __host__ __device__
-void iter_swap(tag, Pointer1, Pointer2)
+void iter_swap(thrust::execution_policy<DerivedPolicy> &, Pointer1, Pointer2)
 {
   // unimplemented
   THRUST_STATIC_ASSERT( (thrust::detail::depend_on_instantiation<Pointer1, false>::value) );

--- a/thrust/system/detail/sequential/iter_swap.h
+++ b/thrust/system/detail/sequential/iter_swap.h
@@ -31,9 +31,9 @@ namespace sequential
 {
 
 
-template<typename Pointer1, typename Pointer2>
+template<typename DerivedPolicy, typename Pointer1, typename Pointer2>
 __host__ __device__
-  void iter_swap(tag, Pointer1 a, Pointer2 b)
+  void iter_swap(sequential::execution_policy<DerivedPolicy> &, Pointer1 a, Pointer2 b)
 {
   using thrust::swap;
   swap(*thrust::raw_pointer_cast(a), *thrust::raw_pointer_cast(b));


### PR DESCRIPTION
This pull request makes iter_swap()'s interface uniform with the other primitives and ought to fix #855. It also introduces a new unit test for device_reference swap.
