### PR TITLE
Fixed unused parameter warnings when calling sort and sort_by_key

### DIFF
--- a/thrust/system/cuda/detail/cub/device/dispatch/device_radix_sort_dispatch.cuh
+++ b/thrust/system/cuda/detail/cub/device/dispatch/device_radix_sort_dispatch.cuh
@@ -531,7 +531,7 @@ struct DeviceRadixSortDispatch
 
         template <typename ScanPolicy, typename ScanKernelPtr>
         CUB_RUNTIME_FUNCTION __forceinline__ cudaError_t InitScanPolicy(
-            int sm_version, int sm_count, ScanKernelPtr scan_kernel)
+            int, int, ScanKernelPtr)
         {
             block_threads               = ScanPolicy::BLOCK_THREADS;
             items_per_thread            = ScanPolicy::ITEMS_PER_THREAD;

--- a/thrust/system/detail/sequential/sort.inl
+++ b/thrust/system/detail/sequential/sort.inl
@@ -54,7 +54,7 @@ __host__ __device__
 void stable_sort(sequential::execution_policy<DerivedPolicy> &exec,
                  RandomAccessIterator first,
                  RandomAccessIterator last,
-                 StrictWeakOrdering comp,
+                 StrictWeakOrdering,
                  thrust::detail::true_type)
 {
   thrust::system::detail::sequential::stable_primitive_sort(exec, first, last);
@@ -78,7 +78,7 @@ void stable_sort_by_key(sequential::execution_policy<DerivedPolicy> &exec,
                         RandomAccessIterator1 first1,
                         RandomAccessIterator1 last1,
                         RandomAccessIterator2 first2,
-                        StrictWeakOrdering comp,
+                        StrictWeakOrdering,
                         thrust::detail::true_type)
 {
   // if comp is greater<T> then reverse the keys and values


### PR DESCRIPTION
This commit fixes the remaining warnings in #846.