### PR TITLE
Fixed many unused-parameter warnings when compiling with -Wall -Wextra

### DIFF
--- a/testing/allocator.cu
+++ b/testing/allocator.cu
@@ -74,7 +74,7 @@ struct my_allocator_with_custom_destroy
 
   template<typename T>
   __host__ __device__
-  void destroy(T *p)
+  void destroy(T *)
   {
 #if !__CUDA_ARCH__
     g_state = 13;

--- a/testing/backend/cuda/for_each.cu
+++ b/testing/backend/cuda/for_each.cu
@@ -6,7 +6,7 @@
 static const size_t NUM_REGISTERS = 64;
 
 template <size_t N> __host__ __device__ void f   (int * x) { int temp = *x; f<N - 1>(x + 1); *x = temp;};
-template <>         __host__ __device__ void f<0>(int * x) { }
+template <>         __host__ __device__ void f<0>(int *)   { }
 template <size_t N>
 struct CopyFunctorWithManyRegisters
 {

--- a/testing/backend/cuda/radix_sort.cu
+++ b/testing/backend/cuda/radix_sort.cu
@@ -60,7 +60,7 @@ void InitializeSimpleStableKeyRadixSortTest(Vector& unsorted_keys, Vector& sorte
 template <class Vector>
 struct TestRadixSortKeySimple
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef typename Vector::value_type T;
 

--- a/testing/backend/cuda/radix_sort_by_key.cu
+++ b/testing/backend/cuda/radix_sort_by_key.cu
@@ -58,7 +58,7 @@ void InitializeSimpleKeyValueRadixSortTest(Vector& unsorted_keys, Vector& unsort
 template <class Vector>
 struct TestRadixSortKeyValueSimple
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef typename Vector::value_type T;
 

--- a/testing/binary_search.cu
+++ b/testing/binary_search.cu
@@ -37,7 +37,7 @@ DECLARE_VECTOR_UNITTEST(TestScalarLowerBoundSimple);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-ForwardIterator lower_bound(my_system &system, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+ForwardIterator lower_bound(my_system &system, ForwardIterator first, ForwardIterator, const LessThanComparable &)
 {
     system.validate_dispatch();
     return first;
@@ -59,7 +59,7 @@ DECLARE_UNITTEST(TestScalarLowerBoundDispatchExplicit);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-ForwardIterator lower_bound(my_tag, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+ForwardIterator lower_bound(my_tag, ForwardIterator first, ForwardIterator, const LessThanComparable &)
 {
     *first = 13;
     return first;
@@ -105,7 +105,7 @@ DECLARE_VECTOR_UNITTEST(TestScalarUpperBoundSimple);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-ForwardIterator upper_bound(my_system &system, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+ForwardIterator upper_bound(my_system &system, ForwardIterator first, ForwardIterator, const LessThanComparable &)
 {
     system.validate_dispatch();
     return first;
@@ -127,7 +127,7 @@ DECLARE_UNITTEST(TestScalarUpperBoundDispatchExplicit);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-ForwardIterator upper_bound(my_tag, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+ForwardIterator upper_bound(my_tag, ForwardIterator first, ForwardIterator, const LessThanComparable &)
 {
     *first = 13;
     return first;
@@ -172,7 +172,7 @@ DECLARE_VECTOR_UNITTEST(TestScalarBinarySearchSimple);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-bool binary_search(my_system &system, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+bool binary_search(my_system &system, ForwardIterator, ForwardIterator, const LessThanComparable &)
 {
     system.validate_dispatch();
     return false;
@@ -194,7 +194,7 @@ DECLARE_UNITTEST(TestScalarBinarySearchDispatchExplicit);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-bool binary_search(my_tag, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+bool binary_search(my_tag, ForwardIterator first, ForwardIterator, const LessThanComparable &)
 {
     *first = 13;
     return false;
@@ -250,7 +250,7 @@ DECLARE_VECTOR_UNITTEST(TestScalarEqualRangeSimple);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-thrust::pair<ForwardIterator,ForwardIterator> equal_range(my_system &system, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+thrust::pair<ForwardIterator,ForwardIterator> equal_range(my_system &system, ForwardIterator first, ForwardIterator, const LessThanComparable &)
 {
     system.validate_dispatch();
     return thrust::make_pair(first,first);
@@ -272,7 +272,7 @@ DECLARE_UNITTEST(TestScalarEqualRangeDispatchExplicit);
 
 
 template<typename ForwardIterator, typename LessThanComparable>
-thrust::pair<ForwardIterator,ForwardIterator> equal_range(my_tag, ForwardIterator first, ForwardIterator last, const LessThanComparable &value)
+thrust::pair<ForwardIterator,ForwardIterator> equal_range(my_tag, ForwardIterator first, ForwardIterator, const LessThanComparable &)
 {
     *first = 13;
     return thrust::make_pair(first,first);

--- a/testing/copy.cu
+++ b/testing/copy.cu
@@ -474,7 +474,7 @@ DECLARE_UNITTEST(TestCopyDispatchImplicit);
 
 
 template<typename InputIterator, typename OutputIterator, typename Predicate>
-OutputIterator copy_if(my_system &system, InputIterator, InputIterator, OutputIterator result, Predicate pred)
+OutputIterator copy_if(my_system &system, InputIterator, InputIterator, OutputIterator result, Predicate)
 {
     system.validate_dispatch();
     return result;
@@ -497,7 +497,7 @@ DECLARE_UNITTEST(TestCopyIfDispatchExplicit);
 
 
 template<typename InputIterator, typename OutputIterator, typename Predicate>
-OutputIterator copy_if(my_tag, InputIterator, InputIterator, OutputIterator result, Predicate pred)
+OutputIterator copy_if(my_tag, InputIterator, InputIterator, OutputIterator result, Predicate)
 {
     *result = 13;
     return result;
@@ -518,7 +518,7 @@ DECLARE_UNITTEST(TestCopyIfDispatchImplicit);
 
 
 template<typename InputIterator1, typename InputIterator2, typename OutputIterator, typename Predicate>
-OutputIterator copy_if(my_system &system, InputIterator1, InputIterator1, InputIterator2, OutputIterator result, Predicate pred)
+OutputIterator copy_if(my_system &system, InputIterator1, InputIterator1, InputIterator2, OutputIterator result, Predicate)
 {
     system.validate_dispatch();
     return result;
@@ -542,7 +542,7 @@ DECLARE_UNITTEST(TestCopyIfStencilDispatchExplicit);
 
 
 template<typename InputIterator1, typename InputIterator2, typename OutputIterator, typename Predicate>
-OutputIterator copy_if(my_tag, InputIterator1, InputIterator1, InputIterator2, OutputIterator result, Predicate pred)
+OutputIterator copy_if(my_tag, InputIterator1, InputIterator1, InputIterator2, OutputIterator result, Predicate)
 {
     *result = 13;
     return result;

--- a/testing/count.cu
+++ b/testing/count.cu
@@ -99,7 +99,7 @@ DECLARE_UNITTEST(TestCountDispatchExplicit);
 
 
 template<typename InputIterator, typename EqualityComparable>
-int count(my_tag, InputIterator first, InputIterator, EqualityComparable x)
+int count(my_tag, InputIterator, InputIterator, EqualityComparable x)
 {
     return x;
 }

--- a/testing/equal.cu
+++ b/testing/equal.cu
@@ -62,7 +62,7 @@ void TestEqual(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestEqual);
 
 template<typename InputIterator1, typename InputIterator2>
-bool equal(my_system &system, InputIterator1 first, InputIterator1, InputIterator2)
+bool equal(my_system &system, InputIterator1, InputIterator1, InputIterator2)
 {
     system.validate_dispatch();
     return false;

--- a/testing/fill.cu
+++ b/testing/fill.cu
@@ -383,7 +383,7 @@ DECLARE_UNITTEST(TestFillWithNonTrivialAssignment);
 
 
 template<typename ForwardIterator, typename T>
-void fill(my_system &system, ForwardIterator first, ForwardIterator, const T&)
+void fill(my_system &system, ForwardIterator, ForwardIterator, const T&)
 {
     system.validate_dispatch();
 }

--- a/testing/functional_placeholders_arithmetic.cu
+++ b/testing/functional_placeholders_arithmetic.cu
@@ -7,7 +7,7 @@
 template<typename Vector> \
   struct TestFunctionalPlaceholders##name \
 { \
-  void operator()(const size_t dummy) \
+  void operator()(const size_t) \
   { \
     static const size_t num_samples = 10000; \
     const size_t zero = 0; \

--- a/testing/functional_placeholders_bitwise.cu
+++ b/testing/functional_placeholders_bitwise.cu
@@ -23,7 +23,7 @@ template<typename T, typename U>
 template<typename Vector> \
   struct TestFunctionalPlaceholders##name \
 { \
-  void operator()(const size_t dummy) \
+  void operator()(const size_t) \
   { \
     static const size_t num_samples = 10000; \
     const size_t zero = 0; \

--- a/testing/functional_placeholders_compound_assignment.cu
+++ b/testing/functional_placeholders_compound_assignment.cu
@@ -7,7 +7,7 @@
 template<typename Vector> \
   struct TestFunctionalPlaceholders##name \
 { \
-  void operator()(const size_t dummy) \
+  void operator()(const size_t) \
   { \
     const size_t num_samples = 10000; \
     typedef typename Vector::value_type T; \

--- a/testing/functional_placeholders_miscellaneous.cu
+++ b/testing/functional_placeholders_miscellaneous.cu
@@ -20,7 +20,7 @@ template<typename T>
 template<typename Vector>
   struct TestFunctionalPlaceholdersValue
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     const size_t n = 10000;
     typedef typename Vector::value_type T;
@@ -45,7 +45,7 @@ VectorUnitTest<TestFunctionalPlaceholdersValue, ThirtyTwoBitTypes, thrust::host_
 template<typename Vector>
   struct TestFunctionalPlaceholdersTransformIterator
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     const size_t n = 10000;
     typedef typename Vector::value_type T;

--- a/testing/gather.cu
+++ b/testing/gather.cu
@@ -174,11 +174,11 @@ template<typename InputIterator1,
          typename RandomAccessIterator,
          typename OutputIterator>
 OutputIterator gather_if(my_system &system,
-                         InputIterator1       map_first,
-                         InputIterator1       map_last,
-                         InputIterator2       stencil,
-                         RandomAccessIterator input_first,
-                         OutputIterator       result)
+                         InputIterator1,
+                         InputIterator1,
+                         InputIterator2,
+                         RandomAccessIterator,
+                         OutputIterator result)
 {
     system.validate_dispatch();
     return result;
@@ -206,11 +206,11 @@ template<typename InputIterator1,
          typename RandomAccessIterator,
          typename OutputIterator>
 OutputIterator gather_if(my_tag,
-                         InputIterator1       map_first,
-                         InputIterator1       map_last,
-                         InputIterator2       stencil,
-                         RandomAccessIterator input_first,
-                         OutputIterator       result)
+                         InputIterator1,
+                         InputIterator1,
+                         InputIterator2,
+                         RandomAccessIterator,
+                         OutputIterator result)
 {
     *result = 13;
     return result;

--- a/testing/generate.cu
+++ b/testing/generate.cu
@@ -40,7 +40,7 @@ DECLARE_VECTOR_UNITTEST(TestGenerateSimple);
 
 
 template<typename ForwardIterator, typename Generator>
-void generate(my_system &system, ForwardIterator first, ForwardIterator, Generator)
+void generate(my_system &system, ForwardIterator, ForwardIterator, Generator)
 {
     system.validate_dispatch();
 }
@@ -92,7 +92,7 @@ void TestGenerate(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestGenerate);
 
 template <typename T>
-void TestGenerateToDiscardIterator(const size_t n)
+void TestGenerateToDiscardIterator(const size_t)
 {
     T value = 13;
     return_value<T> f(value);

--- a/testing/is_partitioned.cu
+++ b/testing/is_partitioned.cu
@@ -62,7 +62,7 @@ DECLARE_VECTOR_UNITTEST(TestIsPartitioned);
 
 
 template<typename InputIterator, typename Predicate>
-bool is_partitioned(my_system &system, InputIterator first, InputIterator, Predicate)
+bool is_partitioned(my_system &system, InputIterator, InputIterator, Predicate)
 {
   system.validate_dispatch();
   return false;

--- a/testing/is_sorted.cu
+++ b/testing/is_sorted.cu
@@ -76,7 +76,7 @@ DECLARE_VECTOR_UNITTEST(TestIsSorted);
 
 
 template<typename InputIterator>
-bool is_sorted(my_system &system, InputIterator first, InputIterator)
+bool is_sorted(my_system &system, InputIterator, InputIterator)
 {
   system.validate_dispatch();
   return false;

--- a/testing/logical.cu
+++ b/testing/logical.cu
@@ -26,7 +26,7 @@ DECLARE_VECTOR_UNITTEST(TestAllOf);
 
 
 template <class InputIterator, class Predicate>
-bool all_of(my_system &system, InputIterator first, InputIterator last, Predicate pred)
+bool all_of(my_system &system, InputIterator, InputIterator, Predicate)
 {
     system.validate_dispatch();
     return false;
@@ -45,7 +45,7 @@ DECLARE_UNITTEST(TestAllOfDispatchExplicit);
 
 
 template <class InputIterator, class Predicate>
-bool all_of(my_tag, InputIterator first, InputIterator last, Predicate pred)
+bool all_of(my_tag, InputIterator first, InputIterator, Predicate)
 {
     *first = 13;
     return false;
@@ -86,7 +86,7 @@ DECLARE_VECTOR_UNITTEST(TestAnyOf);
 
 
 template <class InputIterator, class Predicate>
-bool any_of(my_system &system, InputIterator first, InputIterator last, Predicate pred)
+bool any_of(my_system &system, InputIterator, InputIterator, Predicate)
 {
     system.validate_dispatch();
     return false;
@@ -105,7 +105,7 @@ DECLARE_UNITTEST(TestAnyOfDispatchExplicit);
 
 
 template <class InputIterator, class Predicate>
-bool any_of(my_tag, InputIterator first, InputIterator last, Predicate pred)
+bool any_of(my_tag, InputIterator first, InputIterator, Predicate)
 {
     *first = 13;
     return false;
@@ -146,7 +146,7 @@ DECLARE_VECTOR_UNITTEST(TestNoneOf);
 
 
 template <class InputIterator, class Predicate>
-bool none_of(my_system &system, InputIterator first, InputIterator last, Predicate pred)
+bool none_of(my_system &system, InputIterator, InputIterator, Predicate)
 {
     system.validate_dispatch();
     return false;
@@ -165,7 +165,7 @@ DECLARE_UNITTEST(TestNoneOfDispatchExplicit);
 
 
 template <class InputIterator, class Predicate>
-bool none_of(my_tag, InputIterator first, InputIterator last, Predicate pred)
+bool none_of(my_tag, InputIterator first, InputIterator, Predicate)
 {
     *first = 13;
     return false;

--- a/testing/partition.cu
+++ b/testing/partition.cu
@@ -1147,8 +1147,8 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator partition(my_system &system,
                           ForwardIterator first,
-                          ForwardIterator last,
-                          Predicate pred)
+                          ForwardIterator,
+                          Predicate)
 {
     system.validate_dispatch();
     return first;
@@ -1174,9 +1174,9 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator partition(my_system &system,
                           ForwardIterator first,
-                          ForwardIterator last,
-                          InputIterator stencil,
-                          Predicate pred)
+                          ForwardIterator,
+                          InputIterator,
+                          Predicate)
 {
     system.validate_dispatch();
     return first;
@@ -1202,8 +1202,8 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator partition(my_tag,
                           ForwardIterator first,
-                          ForwardIterator last,
-                          Predicate pred)
+                          ForwardIterator,
+                          Predicate)
 {
     *first = 13;
     return first;
@@ -1227,9 +1227,9 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator partition(my_tag,
                           ForwardIterator first,
-                          ForwardIterator last,
-                          InputIterator stencil,
-                          Predicate pred)
+                          ForwardIterator,
+                          InputIterator,
+                          Predicate)
 {
     *first = 13;
     return first;
@@ -1254,11 +1254,11 @@ template<typename InputIterator,
          typename Predicate>
   thrust::pair<OutputIterator1,OutputIterator2>
     partition_copy(my_system &system,
-                   InputIterator first,
-                   InputIterator last,
+                   InputIterator,
+                   InputIterator,
                    OutputIterator1 out_true,
                    OutputIterator2 out_false,
-                   Predicate pred)
+                   Predicate)
 {
   system.validate_dispatch();
   return thrust::make_pair(out_true,out_false);
@@ -1288,12 +1288,12 @@ template<typename InputIterator1,
          typename Predicate>
   thrust::pair<OutputIterator1,OutputIterator2>
     partition_copy(my_system &system,
-                   InputIterator1 first,
-                   InputIterator1 last,
-                   InputIterator2 stencil,
+                   InputIterator1,
+                   InputIterator1,
+                   InputIterator2,
                    OutputIterator1 out_true,
                    OutputIterator2 out_false,
-                   Predicate pred)
+                   Predicate)
 {
   system.validate_dispatch();
   return thrust::make_pair(out_true,out_false);
@@ -1324,10 +1324,10 @@ template<typename InputIterator,
   thrust::pair<OutputIterator1,OutputIterator2>
     partition_copy(my_tag,
                    InputIterator first,
-                   InputIterator last,
+                   InputIterator,
                    OutputIterator1 out_true,
                    OutputIterator2 out_false,
-                   Predicate pred)
+                   Predicate)
 {
   *first = 13;
   return thrust::make_pair(out_true,out_false);
@@ -1356,11 +1356,11 @@ template<typename InputIterator1,
   thrust::pair<OutputIterator1,OutputIterator2>
     partition_copy(my_tag,
                    InputIterator1 first,
-                   InputIterator1 last,
-                   InputIterator2 stencil,
+                   InputIterator1,
+                   InputIterator2,
                    OutputIterator1 out_true,
                    OutputIterator2 out_false,
-                   Predicate pred)
+                   Predicate)
 {
   *first = 13;
   return thrust::make_pair(out_true,out_false);
@@ -1386,8 +1386,8 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator stable_partition(my_system &system,
                                  ForwardIterator first,
-                                 ForwardIterator last,
-                                 Predicate pred)
+                                 ForwardIterator,
+                                 Predicate)
 {
     system.validate_dispatch();
     return first;
@@ -1413,9 +1413,9 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator stable_partition(my_system &system,
                                  ForwardIterator first,
-                                 ForwardIterator last,
-                                 InputIterator stencil,
-                                 Predicate pred)
+                                 ForwardIterator,
+                                 InputIterator,
+                                 Predicate)
 {
     system.validate_dispatch();
     return first;
@@ -1441,8 +1441,8 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator stable_partition(my_tag,
                                  ForwardIterator first,
-                                 ForwardIterator last,
-                                 Predicate pred)
+                                 ForwardIterator,
+                                 Predicate)
 {
     *first = 13;
     return first;
@@ -1466,9 +1466,9 @@ template<typename ForwardIterator,
          typename Predicate>
 ForwardIterator stable_partition(my_tag,
                                  ForwardIterator first,
-                                 ForwardIterator last,
-                                 InputIterator stencil,
-                                 Predicate pred)
+                                 ForwardIterator,
+                                 InputIterator,
+                                 Predicate)
 {
     *first = 13;
     return first;
@@ -1494,11 +1494,11 @@ template<typename InputIterator,
          typename Predicate>
   thrust::pair<OutputIterator1,OutputIterator2>
     stable_partition_copy(my_system &system,
-                          InputIterator first,
-                          InputIterator last,
+                          InputIterator,
+                          InputIterator,
                           OutputIterator1 out_true,
                           OutputIterator2 out_false,
-                          Predicate pred)
+                          Predicate)
 {
   system.validate_dispatch();
   return thrust::make_pair(out_true,out_false);
@@ -1528,12 +1528,12 @@ template<typename InputIterator1,
          typename Predicate>
   thrust::pair<OutputIterator1,OutputIterator2>
     stable_partition_copy(my_system &system,
-                          InputIterator1 first,
-                          InputIterator1 last,
-                          InputIterator2 stencil,
+                          InputIterator1,
+                          InputIterator1,
+                          InputIterator2,
                           OutputIterator1 out_true,
                           OutputIterator2 out_false,
-                          Predicate pred)
+                          Predicate)
 {
   system.validate_dispatch();
   return thrust::make_pair(out_true,out_false);
@@ -1564,10 +1564,10 @@ template<typename InputIterator,
   thrust::pair<OutputIterator1,OutputIterator2>
     stable_partition_copy(my_tag,
                           InputIterator first,
-                          InputIterator last,
+                          InputIterator,
                           OutputIterator1 out_true,
                           OutputIterator2 out_false,
-                          Predicate pred)
+                          Predicate)
 {
   *first = 13;
   return thrust::make_pair(out_true,out_false);
@@ -1596,11 +1596,11 @@ template<typename InputIterator1,
   thrust::pair<OutputIterator1,OutputIterator2>
     stable_partition_copy(my_tag,
                           InputIterator1 first,
-                          InputIterator1 last,
-                          InputIterator2 stencil,
+                          InputIterator1,
+                          InputIterator2,
                           OutputIterator1 out_true,
                           OutputIterator2 out_false,
-                          Predicate pred)
+                          Predicate)
 {
   *first = 13;
   return thrust::make_pair(out_true,out_false);

--- a/testing/partition_point.cu
+++ b/testing/partition_point.cu
@@ -51,8 +51,8 @@ DECLARE_VECTOR_UNITTEST(TestPartitionPoint);
 template<typename ForwardIterator, typename Predicate>
 ForwardIterator partition_point(my_system &system, 
                                 ForwardIterator first,
-                                ForwardIterator last,
-                                Predicate pred)
+                                ForwardIterator,
+                                Predicate)
 {
   system.validate_dispatch();
   return first;
@@ -76,8 +76,8 @@ DECLARE_UNITTEST(TestPartitionPointDispatchExplicit);
 template<typename ForwardIterator, typename Predicate>
 ForwardIterator partition_point(my_tag,
                                 ForwardIterator first,
-                                ForwardIterator last,
-                                Predicate pred)
+                                ForwardIterator,
+                                Predicate)
 {
   *first = 13;
   return first;

--- a/testing/remove.cu
+++ b/testing/remove.cu
@@ -210,7 +210,7 @@ template<typename ForwardIterator,
 ForwardIterator remove_if(my_system &system,
                           ForwardIterator first,
                           ForwardIterator,
-                          Predicate pred)
+                          Predicate)
 {
     system.validate_dispatch();
     return first;
@@ -233,7 +233,7 @@ template<typename ForwardIterator,
 ForwardIterator remove_if(my_tag,
                           ForwardIterator first,
                           ForwardIterator,
-                          Predicate pred)
+                          Predicate)
 {
     *first = 13;
     return first;
@@ -292,7 +292,7 @@ ForwardIterator remove_if(my_system &system,
                           ForwardIterator first,
                           ForwardIterator,
                           InputIterator,
-                          Predicate pred)
+                          Predicate)
 {
     system.validate_dispatch();
     return first;
@@ -321,7 +321,7 @@ ForwardIterator remove_if(my_tag,
                           ForwardIterator first,
                           ForwardIterator,
                           InputIterator,
-                          Predicate pred)
+                          Predicate)
 {
     *first = 13;
     return first;

--- a/testing/replace.cu
+++ b/testing/replace.cu
@@ -33,7 +33,7 @@ DECLARE_VECTOR_UNITTEST(TestReplaceSimple);
 
 template<typename ForwardIterator, typename T>
 void replace(my_system &system,
-             ForwardIterator first, ForwardIterator, const T &,
+             ForwardIterator, ForwardIterator, const T &,
              const T &)
 {
     system.validate_dispatch();
@@ -256,7 +256,7 @@ DECLARE_VECTOR_UNITTEST(TestReplaceIfSimple);
 
 template<typename ForwardIterator, typename Predicate, typename T>
 void replace_if(my_system &system,
-                ForwardIterator first, ForwardIterator,
+                ForwardIterator, ForwardIterator,
                 Predicate,
                 const T &)
 {
@@ -337,7 +337,7 @@ DECLARE_VECTOR_UNITTEST(TestReplaceIfStencilSimple);
 
 template<typename ForwardIterator, typename InputIterator, typename Predicate, typename T>
 void replace_if(my_system &system,
-                ForwardIterator first, ForwardIterator,
+                ForwardIterator, ForwardIterator,
                 InputIterator,
                 Predicate,
                 const T &)

--- a/testing/reverse.cu
+++ b/testing/reverse.cu
@@ -32,8 +32,8 @@ DECLARE_VECTOR_UNITTEST(TestReverseSimple);
 
 template<typename BidirectionalIterator>
 void reverse(my_system &system,
-             BidirectionalIterator first,
-             BidirectionalIterator last)
+             BidirectionalIterator,
+             BidirectionalIterator)
 {
   system.validate_dispatch();
 }
@@ -53,7 +53,7 @@ DECLARE_UNITTEST(TestReverseDispatchExplicit);
 template<typename BidirectionalIterator>
 void reverse(my_tag,
              BidirectionalIterator first,
-             BidirectionalIterator last)
+             BidirectionalIterator)
 {
   *first = 13;
 }

--- a/testing/scan_by_key.cu
+++ b/testing/scan_by_key.cu
@@ -240,7 +240,7 @@ struct head_flag_predicate
 {
     template <typename T>
     __host__ __device__
-    bool operator()(const T& a, const T& b)
+    bool operator()(const T&, const T& b)
     {
         return b ? false : true;
     }

--- a/testing/scatter.cu
+++ b/testing/scatter.cu
@@ -39,7 +39,7 @@ void scatter(my_system &system,
              InputIterator1,
              InputIterator1,
              InputIterator2,
-             RandomAccessIterator output)
+             RandomAccessIterator)
 {
     system.validate_dispatch();
 }
@@ -172,7 +172,7 @@ void scatter_if(my_system &system,
                 InputIterator1,
                 InputIterator2,
                 InputIterator3,
-                RandomAccessIterator output)
+                RandomAccessIterator)
 {
     system.validate_dispatch();
 }

--- a/testing/sequence.cu
+++ b/testing/sequence.cu
@@ -5,7 +5,7 @@
 
 
 template<typename ForwardIterator>
-void sequence(my_system &system, ForwardIterator first, ForwardIterator)
+void sequence(my_system &system, ForwardIterator, ForwardIterator)
 {
     system.validate_dispatch();
 }

--- a/testing/tabulate.cu
+++ b/testing/tabulate.cu
@@ -6,7 +6,7 @@
 
 
 template<typename ForwardIterator, typename UnaryOperation>
-void tabulate(my_system &system, ForwardIterator first, ForwardIterator, UnaryOperation unary_op)
+void tabulate(my_system &system, ForwardIterator, ForwardIterator, UnaryOperation)
 {
   system.validate_dispatch();
 }
@@ -24,7 +24,7 @@ DECLARE_UNITTEST(TestTabulateDispatchExplicit);
 
 
 template<typename ForwardIterator, typename UnaryOperation>
-void tabulate(my_tag, ForwardIterator first, ForwardIterator, UnaryOperation unary_op)
+void tabulate(my_tag, ForwardIterator first, ForwardIterator, UnaryOperation)
 {
   *first = 13;
 }

--- a/testing/testframework.cpp
+++ b/testing/testframework.cpp
@@ -132,7 +132,7 @@ void process_args(int argc, char ** argv,
 }
 
 
-void usage(int argc, char** argv)
+void usage(int, char** argv)
 {
   std::string indent = "  ";
   
@@ -257,7 +257,7 @@ void UnitTestDriver::list_tests(void)
 }
 
 
-bool UnitTestDriver::post_test_sanity_check(const UnitTest &test, bool concise)
+bool UnitTestDriver::post_test_sanity_check(const UnitTest &, bool)
 {
   return true;
 }

--- a/testing/uninitialized_copy.cu
+++ b/testing/uninitialized_copy.cu
@@ -145,7 +145,7 @@ struct CopyConstructTest
   {}
 
   __host__ __device__
-  CopyConstructTest(const CopyConstructTest &exemplar)
+  CopyConstructTest(const CopyConstructTest &)
   {
 #if __CUDA_ARCH__
     copy_constructed_on_device = true;
@@ -171,7 +171,7 @@ struct CopyConstructTest
 
 struct TestUninitializedCopyNonPODDevice
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef CopyConstructTest T;
 
@@ -197,7 +197,7 @@ DECLARE_UNITTEST(TestUninitializedCopyNonPODDevice);
 
 struct TestUninitializedCopyNNonPODDevice
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef CopyConstructTest T;
 
@@ -223,7 +223,7 @@ DECLARE_UNITTEST(TestUninitializedCopyNNonPODDevice);
 
 struct TestUninitializedCopyNonPODHost
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef CopyConstructTest T;
 
@@ -249,7 +249,7 @@ DECLARE_UNITTEST(TestUninitializedCopyNonPODHost);
 
 struct TestUninitializedCopyNNonPODHost
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef CopyConstructTest T;
 

--- a/testing/uninitialized_fill.cu
+++ b/testing/uninitialized_fill.cu
@@ -153,7 +153,7 @@ struct CopyConstructTest
   {}
 
   __host__ __device__
-  CopyConstructTest(const CopyConstructTest &exemplar)
+  CopyConstructTest(const CopyConstructTest &)
   {
 #if __CUDA_ARCH__
     copy_constructed_on_device = true;
@@ -179,7 +179,7 @@ struct CopyConstructTest
 
 struct TestUninitializedFillNonPOD
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef CopyConstructTest T;
     thrust::device_ptr<T> v = thrust::device_malloc<T>(5);
@@ -265,7 +265,7 @@ DECLARE_VECTOR_UNITTEST(TestUninitializedFillNPOD);
 
 struct TestUninitializedFillNNonPOD
 {
-  void operator()(const size_t dummy)
+  void operator()(const size_t)
   {
     typedef CopyConstructTest T;
     thrust::device_ptr<T> v = thrust::device_malloc<T>(5);

--- a/testing/unittest/meta.h
+++ b/testing/unittest/meta.h
@@ -133,7 +133,7 @@ template<typename TypeList,
   struct for_each_type<TypeList, Function, null_type, i>
 {
   template<typename U>
-    void operator()(U n)
+    void operator()(U)
   {
     // no-op
   }

--- a/testing/vector_insert.cu
+++ b/testing/vector_insert.cu
@@ -5,7 +5,7 @@
 template <class Vector>
 struct TestVectorRangeInsertSimple
 {
-    void operator()(size_t dummy)
+    void operator()(size_t)
     {
         Vector v1(5);
         thrust::sequence(v1.begin(), v1.end());
@@ -171,7 +171,7 @@ VariableUnitTest<TestVectorRangeInsert, IntegralTypes> TestVectorRangeInsertInst
 template <class Vector>
 struct TestVectorFillInsertSimple
 {
-    void operator()(size_t dummy)
+    void operator()(size_t)
     {
         // test when insertion range fits inside capacity
         // and the size of the insertion is greater than the number

--- a/thrust/detail/allocator/allocator_traits.inl
+++ b/thrust/detail/allocator/allocator_traits.inl
@@ -87,7 +87,7 @@ template<typename Alloc, typename T>
     typename disable_if<
       has_member_construct1<Alloc,T>::value
     >::type
-      construct(Alloc &a, T *p)
+      construct(Alloc &, T *p)
 {
   ::new(static_cast<void*>(p)) T();
 }

--- a/thrust/detail/allocator/copy_construct_range.inl
+++ b/thrust/detail/allocator/copy_construct_range.inl
@@ -92,7 +92,7 @@ __host__ __device__
     Pointer
   >::type
     uninitialized_copy_with_allocator(Allocator &a,
-                                      const thrust::execution_policy<FromSystem> &from_system,
+                                      const thrust::execution_policy<FromSystem> &,
                                       const thrust::execution_policy<ToSystem> &to_system,
                                       InputIterator first,
                                       InputIterator last,
@@ -134,7 +134,7 @@ __host__ __device__
     Pointer
   >::type
     uninitialized_copy_with_allocator_n(Allocator &a,
-                                        const thrust::execution_policy<FromSystem> &from_system,
+                                        const thrust::execution_policy<FromSystem> &,
                                         const thrust::execution_policy<ToSystem> &to_system,
                                         InputIterator first,
                                         Size n,

--- a/thrust/functional.h
+++ b/thrust/functional.h
@@ -1155,7 +1155,7 @@ struct project1st
 
   /*! Function call operator. The return value is <tt>lhs</tt>.
    */
-  __host__ __device__ const T1 &operator()(const T1 &lhs, const T2 &rhs) const {return lhs;}
+  __host__ __device__ const T1 &operator()(const T1 &lhs, const T2 &) const {return lhs;}
 }; // end project1st
 
 /*! \p project2nd is a function object that takes two arguments and returns 
@@ -1196,7 +1196,7 @@ struct project2nd
 
   /*! Function call operator. The return value is <tt>rhs</tt>.
    */
-  __host__ __device__ const T2 &operator()(const T1 &lhs, const T2 &rhs) const {return rhs;}
+  __host__ __device__ const T2 &operator()(const T1 &, const T2 &rhs) const {return rhs;}
 }; // end project2nd
 
 /*! \}

--- a/thrust/system/cuda/detail/detail/stable_merge_sort.inl
+++ b/thrust/system/cuda/detail/detail/stable_merge_sort.inl
@@ -243,7 +243,7 @@ template<unsigned int work_per_thread,
          typename Compare>
 __host__ __device__
 void merge_adjacent_partitions(thrust::system::cuda::execution_policy<DerivedPolicy> &exec,
-                               Context context,
+                               Context,
                                unsigned int block_size,
                                Size num_blocks_per_merge,
                                Iterator1 first,

--- a/thrust/system/cuda/detail/detail/stable_sort_each.inl
+++ b/thrust/system/cuda/detail/detail/stable_sort_each.inl
@@ -285,7 +285,7 @@ template<unsigned int work_per_thread,
          typename Compare>
 __host__ __device__
 void stable_sort_each_copy(execution_policy<DerivedPolicy> &exec,
-                           Context context,
+                           Context,
                            unsigned int block_size,
                            RandomAccessIterator1 first, RandomAccessIterator1 last,
                            Pointer virtual_smem,

--- a/thrust/system/cuda/experimental/pinned_allocator.h
+++ b/thrust/system/cuda/experimental/pinned_allocator.h
@@ -173,7 +173,7 @@ template<typename T>
      *        the objects stored at \p p.
      */
     __host__
-    inline void deallocate(pointer p, size_type cnt)
+    inline void deallocate(pointer p, size_type)
     {
       cudaError_t error = cudaFreeHost(p);
       

--- a/thrust/system/detail/generic/replace.inl
+++ b/thrust/system/detail/generic/replace.inl
@@ -70,7 +70,7 @@ template<typename T>
 
   template<typename U>
   __host__ __device__
-  T operator()(U &x)
+  T operator()(U &)
   {
     return c;
   } // end operator()()

--- a/thrust/system/detail/sequential/merge.inl
+++ b/thrust/system/detail/sequential/merge.inl
@@ -82,7 +82,7 @@ template<typename DerivedPolicy,
          typename StrictWeakOrdering>
 __host__ __device__
 thrust::pair<OutputIterator1,OutputIterator2>
-  merge_by_key(sequential::execution_policy<DerivedPolicy> &exec,
+  merge_by_key(sequential::execution_policy<DerivedPolicy> &,
                InputIterator1 keys_first1,
                InputIterator1 keys_last1,
                InputIterator2 keys_first2,

--- a/thrust/system/detail/sequential/unique.h
+++ b/thrust/system/detail/sequential/unique.h
@@ -42,7 +42,7 @@ template<typename DerivedPolicy,
          typename OutputIterator,
          typename BinaryPredicate>
 __host__ __device__
-  OutputIterator unique_copy(sequential::execution_policy<DerivedPolicy> &exec,
+  OutputIterator unique_copy(sequential::execution_policy<DerivedPolicy> &,
                              InputIterator first,
                              InputIterator last,
                              OutputIterator output,


### PR DESCRIPTION
Hi,

after I discovered more unused-parameter warnings when using thrust::sort, I've decided to try fixing them once and for all. Assuming that the unit tests cover all functions, I've built the tests with `-Wall -Wextra` and fixed (nearly) all warnings that appeared.
Only some `floating-point value does not fit in required integral type` warnings cannot be fixed since `std::numeric_limits<float>::max()` will never fit into `size_t`. So this warning will still be thrown.

I've also tested the proposed PR and got this result:
```
================================================================
KNOWN FAILURE: TestDeviceDeleteDestructorInvocation
[testing/device_delete.cu:30]
================================================================
KNOWN FAILURE: TestScanWithLargeTypes
[testing/scan.cu:504]
================================================================
Totals: 0 failures, 2 known failures, 0 errors, and 1390 passes. 
```
System:
- Kubuntu 14.04
- gcc : 4.8.4
- nvcc : CUDA 8.0.44 on a NVIDIA GTX TITAN X with Compute Capability 5.2

I assume that this is fine and expected. Let me know if you wish any changes on this PR.


Kind regards,
Patrick