### PR TITLE
Fixed minor documentation error with thrust::minus

### DIFF
--- a/thrust/functional.h
+++ b/thrust/functional.h
@@ -222,7 +222,7 @@ struct plus
  *
  *  thrust::transform(V1.begin(), V1.end(), V2.begin(), V3.begin(),
  *                     thrust::minus<float>());
- *  // V3 is now {-74, -75, -76, ..., -925}
+ *  // V3 is now {-74, -73, -72, ..., 925}
  *  \endcode
  *
  *  \see http://www.sgi.com/tech/stl/minus.html


### PR DESCRIPTION
The output that the documentation stated should result from the example code was incorrect, and was the output that would have resulted if the arguments to thrust::transform were inverted.