### PR TITLE
Update pinned_allocator.h

### DIFF
--- a/thrust/system/cuda/experimental/pinned_allocator.h
+++ b/thrust/system/cuda/experimental/pinned_allocator.h
@@ -201,7 +201,7 @@ template<typename T>
      *  \return This method always returns \c true.
      */
     __host__ __device__
-    inline bool operator==(pinned_allocator const& x) { return true; }
+    inline bool operator==(pinned_allocator const& x) const { return true; }
 
     /*! This method tests this \p pinned_allocator for inequality
      *  to another.
@@ -210,7 +210,7 @@ template<typename T>
      *  \return This method always returns \c false.
      */
     __host__ __device__
-    inline bool operator!=(pinned_allocator const &x) { return !operator==(x); }
+    inline bool operator!=(pinned_allocator const &x) const { return !operator==(x); }
 }; // end pinned_allocator
 
 /*! \}


### PR DESCRIPTION
operator== and operator!= should be const. This is causing compilation issues on VS 2015 when assigning two std::vector<T, pinned_allocator<T>>