### PR TITLE
Fix UB when append is called on an empty vector

### DIFF
--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -808,8 +808,11 @@ template<typename T, typename Alloc>
 
       try
       {
-        // construct copy all elements into the newly allocated storage
-        new_end = m_storage.uninitialized_copy(begin(), end(), new_storage.begin());
+        if( begin() != end() )
+        {
+          // construct copy all elements into the newly allocated storage
+          new_end = m_storage.uninitialized_copy(begin(), end(), new_storage.begin());
+        } // end if
 
         // construct new elements to insert
         m_storage.default_construct_n(new_end, n);


### PR DESCRIPTION
When a vector is default constructed, m_storage.begin() is a null
pointer. In a subsequent resize of that vector, call to append will try
to copy old data begin to end into a new location, thus de-referencing
m_storage.begin() which is UB.

Added check that vector_base.begin() is different from end() to copy