### PR TITLE
cuda/detail/malloc_and_free doesn't include thrust/system/cuda/memory.h

### DIFF
--- a/thrust/system/cuda/detail/malloc_and_free.h
+++ b/thrust/system/cuda/detail/malloc_and_free.h
@@ -19,15 +19,16 @@
 #include <thrust/system/cuda/detail/guarded_cuda_runtime_api.h>
 
 #include <thrust/detail/config.h>
+#include <thrust/detail/raw_pointer_cast.h>
+#include <thrust/detail/raw_reference_cast.h>
 #include <thrust/detail/seq.h>
-#include <thrust/memory.h>
 #include <thrust/system/cuda/config.h>
 #ifdef THRUST_CACHING_DEVICE_MALLOC
 #include <cub/util_allocator.cuh>
 #endif
 #include <thrust/system/cuda/detail/util.h>
 #include <thrust/system/detail/bad_alloc.h>
-
+#include <thrust/detail/malloc_and_free.h>
 
 namespace thrust
 {


### PR DESCRIPTION
The comments inside cuda/detail/malloc_and_free.h state that
they don't want to include thrust/system/cuda/memory.h as it
is heavy-weight. It was inadvertently doing so through thrust/memory.h,
and so I have correct this oversight.