### PR TITLE
thrust::system::cuda::allocator constructor should be host only

### DIFF
--- a/thrust/system/cuda/memory.h
+++ b/thrust/system/cuda/memory.h
@@ -100,7 +100,7 @@ public:
 
   /*! No-argument constructor has no effect.
    */
-  __host__ __device__
+  __host__
   inline allocator() {}
 
   /*! Copy constructor has no effect.


### PR DESCRIPTION
Fixes #972.
The constructor of this allocator has no need to be device constructible.