### PR TITLE
Avoid returning uninitialized allocator

### DIFF
--- a/thrust/detail/allocator/allocator_traits.inl
+++ b/thrust/detail/allocator/allocator_traits.inl
@@ -246,9 +246,8 @@ __host__ __device__
   >::type
     system(Alloc &)
 {
-  // return a copy of a default-constructed system
-  typename allocator_system<Alloc>::type result;
-  return result;
+  // return a copy of a value-initialized system
+  return typename allocator_system<Alloc>::type();
 }
 
 


### PR DESCRIPTION
This is caught by MSVC Debug build.  There is no customized allocators being used, just host_vector and device_vector.

![image](https://user-images.githubusercontent.com/43971430/62740277-08fa5a00-b9fd-11e9-91d5-fbf8e65e7201.png)
