### PR TITLE
Don't call the destruction kernel for an empty vector

### DIFF
--- a/doc/branching.md
+++ b/doc/branching.md
@@ -13,6 +13,7 @@ versions don't directly map to any CUDA Toolkit version.
 
 | Thrust version    | CUDA version  |
 | ----------------- | ------------- |
+| 1.9.6             | 10.1 Update 2 |
 | 1.9.5             | 10.1 Update 1 |
 | 1.9.4             | 10.1          |
 | 1.9.3             | 10.0          |

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,21 @@
+# Thrust v1.9.6  (CUDA 10.1 Update 2) #
+
+## Summary
+
+Thrust v1.9.6 is a minor release accompanying the CUDA 10.1 Update 2 release.
+
+## Bug Fixes
+
+- NVBug 2509847 Inconsistent alignment of `thrust::complex`
+- NVBug 2586774 Compilation failure with Clang + older libstdc++ that doesn't
+    have `std::is_trivially_copyable`
+- NVBug 200488234 CUDA header files contain unicode characters which leads
+    compiling errors on Windows
+- #949, #973, NVBug 2422333, NVBug 2522259, NVBug 2528822 `thrust::detail::aligned_reinterpret_cast`
+    must be annotated with __host__ __device__
+- NVBug 2599629 Missing include in the OpenMP sort implementation
+- NVBug 200513211 Truncation warning in test code under VC142
+
 # Thrust v1.9.5  (CUDA 10.1 Update 1)
 
 ## Summary

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -556,7 +556,8 @@ template<typename T, typename Alloc>
     ::~vector_base(void)
 {
   // destroy every living thing
-  m_storage.destroy(begin(),end());
+  if (!empty())
+    m_storage.destroy(begin(),end());
 } // end vector_base::~vector_base()
 
 template<typename T, typename Alloc>
@@ -1028,7 +1029,7 @@ template<typename T, typename Alloc>
   {
     *current = *first;
   } // end for
-  
+
   // either just the input was exhausted or both
   // the input and vector elements were exhausted
   if(first == last)
@@ -1079,7 +1080,7 @@ template<typename T, typename Alloc>
   {
     // range fits inside allocated storage, but some elements
     // have not been constructed yet
-    
+
     // XXX TODO we could possibly implement this with one call
     // to transform rather than copy + uninitialized_copy
 
@@ -1161,7 +1162,7 @@ template<typename T, typename Alloc>
   } // end try
   catch(...)
   {
-    // something went wrong, so destroy & deallocate the new storage 
+    // something went wrong, so destroy & deallocate the new storage
     // XXX seems like this destroys too many elements -- should just be last - first instead of requested_size
     iterator new_storage_end = new_storage.begin();
     thrust::advance(new_storage_end, requested_size);
@@ -1187,7 +1188,7 @@ template<typename T, typename Alloc>
 
 namespace detail
 {
-    
+
 // iterator tags match
 template <typename InputIterator1, typename InputIterator2>
 bool vector_equal(InputIterator1 first1, InputIterator1 last1,
@@ -1243,7 +1244,7 @@ bool operator==(const detail::vector_base<T1,Alloc1>& lhs,
 {
     return lhs.size() == rhs.size() && detail::vector_equal(lhs.begin(), lhs.end(), rhs.begin());
 }
-    
+
 template<typename T1, typename Alloc1,
          typename T2, typename Alloc2>
 bool operator==(const detail::vector_base<T1,Alloc1>& lhs,
@@ -1267,7 +1268,7 @@ bool operator!=(const detail::vector_base<T1,Alloc1>& lhs,
 {
     return !(lhs == rhs);
 }
-    
+
 template<typename T1, typename Alloc1,
          typename T2, typename Alloc2>
 bool operator!=(const detail::vector_base<T1,Alloc1>& lhs,

--- a/thrust/version.h
+++ b/thrust/version.h
@@ -47,7 +47,7 @@
  *         <tt>THRUST_VERSION / 100 % 1000</tt> is the minor version.
  *         <tt>THRUST_VERSION / 100000</tt> is the major version.
  */
-#define THRUST_VERSION 100906
+#define THRUST_VERSION 100907
 
 /*! \def THRUST_MAJOR_VERSION
  *  \brief The preprocessor macro \p THRUST_MAJOR_VERSION encodes the


### PR DESCRIPTION
When destroying a Thrust vector, we should avoid calling `destroy` if the vector is empty. For a `device_vector`, destroy calls into parallel algorithm machinery, which doesn't currently early exit (or early exit enough) for empty ranges.

This is a fix for Bug 2720132.