### PR TITLE
CMake: Use correct MSVC version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ if ("TBB" STREQUAL "${THRUST_DEVICE_SYSTEM}")
 endif ()
 
 if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 1900)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.00)
     message(FATAL_ERROR "This version of MSVC no longer supported.")
   endif ()
 endif ()


### PR DESCRIPTION
The cmake VERSION_LESS comparison expects versions to be formatted as major.minor.patch.tweak, the current MSVC version is 19.23.28105.4.
The current comparison checking agains 1900.0.0.0 instead of 19.0.0.0, this PR corrects that