### PR TITLE
Fix tuple_for_each unused variable macro and tests

### DIFF
--- a/testing/tuple_algorithms.cu
+++ b/testing/tuple_algorithms.cu
@@ -16,6 +16,16 @@ struct custom_square
   }
 };
 
+void test_tuple_subset()
+{
+  auto t0 = std::make_tuple(0, 2, 3.14);
+
+  auto t1 = thrust::tuple_subset(t0, std::index_sequence<2, 0>{}); 
+
+  ASSERT_EQUAL_QUIET(t1, std::make_tuple(3.14, 0));
+}
+DECLARE_UNITTEST(test_tuple_subset);
+
 void test_tuple_transform()
 {
   auto t0 = std::make_tuple(0, 2, 3.14);
@@ -25,6 +35,16 @@ void test_tuple_transform()
   ASSERT_EQUAL_QUIET(t1, std::make_tuple(0, 4, 9.8596));
 }
 DECLARE_UNITTEST(test_tuple_transform);
+
+void test_tuple_for_each()
+{
+  auto t = std::make_tuple(0, 2, 3.14);
+
+  thrust::tuple_for_each(t, [](auto& x) { x *= x; }); 
+
+  ASSERT_EQUAL_QUIET(t, std::make_tuple(0, 4, 9.8596));
+}
+DECLARE_UNITTEST(test_tuple_for_each);
  
 #endif // THRUST_CPP_DIALECT >= 2011
 

--- a/thrust/detail/tuple_algorithms.h
+++ b/thrust/detail/tuple_algorithms.h
@@ -39,7 +39,7 @@ template <typename Tuple, typename F, std::size_t... Is>
 void tuple_for_each_impl(Tuple&& t, F&& f, index_sequence<Is...>)
 {
   auto l = { (f(std::get<Is>(t)), 0)... };
-  THRUST_UNUSED(l);
+  THRUST_UNUSED_VAR(l);
 }
 
 template <typename Tuple, typename F, std::size_t... Is>


### PR DESCRIPTION
The incorrect macro is used for removing the unused variable warning so this PR corrects that and adds tests for the other 2 tuple algorithms