### PR TITLE
Define THRUST_CPP_DIALECT correctly under MSVC

### DIFF
--- a/thrust/detail/config/cpp_dialect.h
+++ b/thrust/detail/config/cpp_dialect.h
@@ -16,13 +16,19 @@
 
 #pragma once
 
-#if   __cplusplus < 201103L
+#ifdef _MSC_VER
+  #define THRUST_CPP_VER _MSVC_LANG
+#else
+  #define THRUST_CPP_VER __cplusplus
+#endif
+
+#if   THRUST_CPP_VER < 201103L
   #define THRUST_CPP03
   #define THRUST_CPP_DIALECT 2003
-#elif __cplusplus < 201402L
+#elif THRUST_CPP_VER < 201402L
   #define THRUST_CPP11
   #define THRUST_CPP_DIALECT 2011
-#elif __cplusplus < 201703L
+#elif THRUST_CPP_VER < 201703L
   #define THRUST_CPP14
   #define THRUST_CPP_DIALECT 2014
 #else
@@ -30,3 +36,4 @@
   #define THRUST_CPP_DIALECT 2017
 #endif
 
+#undef THRUST_CPP_VER


### PR DESCRIPTION
MSVC doesnt define __cplusplus correctly unless a compiler flag is passed (/Zc:__cplusplus) but _MSVC_LANG is defined correctly.
To avoid users needing to pass an extra compile flag, I suggest we handle it in the cpp_dialect.h file