### PR TITLE
Fix return type of predicate_to_integral::operator()

### DIFF
--- a/thrust/detail/internal_functional.h
+++ b/thrust/detail/internal_functional.h
@@ -97,7 +97,7 @@ struct predicate_to_integral
   
   template <typename T>
   __host__ __device__
-  bool operator()(const T& x)
+  IntegralType operator()(const T& x)
   {
     return pred(x) ? IntegralType(1) : IntegralType(0);
   }


### PR DESCRIPTION
Judging by the name of the functor `predicate_to_integral` and the explicit construction of `IntegralType` in the function, the return type should be `IntegralType` instead of `bool`.