### PR TITLE
Fix specialization of is_error_code_enum

### DIFF
--- a/thrust/detail/event_error.h
+++ b/thrust/detail/event_error.h
@@ -106,8 +106,11 @@ inline error_category const& event_category()
   return result;
 }
 
+namespace system
+{
 /// Specialization of \p is_error_code_enum for \p event_errc.
 template<> struct is_error_code_enum<event_errc> : true_type {};
+} // end system
 
 /// \return <tt>error_code(static_cast<int>(e), event_category())</tt>
 inline error_code make_error_code(event_errc e)


### PR DESCRIPTION
Hi,

First of all, thank you for developing and maintaining this amazing library. It makes CUDA programming drastically easier and fun.

Today I found a problem. When I defined a function that returns `thrust::future` like the following,

```cpp
#include <thrust/future.h>
#include <iostream>

// the definition is in a .cu file and will be linked later
thrust::system::cuda::unique_eager_future<int> do_something();

int main()
{
    auto f = do_something();
    std::cout << f.get() << std::endl;
    return 0;
}
```

and compiled with gcc-8.2.0 (nvcc also shows the same result), the compilation fails with an error message like this.

```console
$ g++-8 -std=c++11 -O2 -c main.cpp -I/usr/local/cuda/include/
In file included from /usr/local/cuda/include/thrust/system/cuda/detail/future.inl:26,
                 from /usr/local/cuda/include/thrust/system/cuda/future.h:71,
                 from /usr/local/cuda/include/thrust/future.h:55,
                 from main.cpp:1:
/usr/local/cuda/include/thrust/detail/event_error.h:110:19: error: explicit specialization of ‘template<class T> struct thrust::system::is_error_code_enum’ outside its namespace must use a nested-name-specifier [-fpermissive]
 template<> struct is_error_code_enum<event_errc> : true_type {};
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I also found that this error can be avoided by applying the patch I'm now sending.

I have tested it only with thrust 1.9.4 that is installed with CUDA 10.1 because it is the version installed in my environment. If the same problem has already been reported and solved, please just close this.

Could you please check it?