### PR TITLE
Actually throw `bad_alloc` from `cuda_cub::malloc`.

### DIFF
--- a/thrust/system/cuda/detail/malloc_and_free.h
+++ b/thrust/system/cuda/detail/malloc_and_free.h
@@ -63,7 +63,7 @@ void *malloc(execution_policy<DerivedPolicy> &, std::size_t n)
   if(status != cudaSuccess)
   {
     cudaGetLastError(); // Clear global CUDA error state.
-    thrust::system::detail::bad_alloc(thrust::cuda_category().message(status).c_str());
+    throw thrust::system::detail::bad_alloc(thrust::cuda_category().message(status).c_str());
   }
 #else
   result = thrust::raw_pointer_cast(thrust::malloc(thrust::seq, n));


### PR DESCRIPTION
`cuda_cub::malloc` constructed a temporary `bad_alloc` instead of actually throwing it.

Tracked internally as bug 2813126.

Internal CI:
- http://ausdvs.nvidia.com/Build_Results?virtualId=1000568807&which_page=current_build
- http://scdvs.nvidia.com/Build_Results?virtualId=1000049159&which_page=current_build






