### PR TITLE
Build CUDA tests with `-rdc=true` in internal Makefiles

### DIFF
--- a/internal/benchmark/bench.cu
+++ b/internal/benchmark/bench.cu
@@ -393,7 +393,6 @@ struct experiment_driver
     );
     #endif
 
-/*
     stl_average_walltime = round_to_precision(
         stl_average_walltime, stl_walltime_precision
     );
@@ -417,7 +416,6 @@ struct experiment_driver
         tbb_walltime_uncertainty, tbb_walltime_precision
     );
     #endif
-*/
 
     // Round the average throughput and throughput uncertainty to the
     // significant figure of the throughput uncertainty.
@@ -436,7 +434,6 @@ struct experiment_driver
     );
     #endif
 
-/*
     stl_average_throughput = round_to_precision(
         stl_average_throughput, stl_throughput_precision
     );
@@ -460,7 +457,6 @@ struct experiment_driver
         tbb_throughput_uncertainty, tbb_throughput_precision
     );
     #endif
-*/
 
     std::cout << THRUST_VERSION                // Thrust Version.
       << ","  << test_name                     // Algorithm.

--- a/internal/build/common_build.mk
+++ b/internal/build/common_build.mk
@@ -11,31 +11,6 @@ ifeq ($(OS),win32)
   CUDACC_FLAGS += -Xcompiler "/bigobj"
 endif
 
-ARCH_NEG_FILTER += 20 21
-# Determine which SASS to generate
-# if DVS (either per-CL or on-demand)
-ifneq ($(or $(THRUST_DVS),$(THRUST_DVS_NIGHTLY)),)
-  # DVS doesn't run Thrust on fermi so filter out SM 2.0/2.1
-  # DVS doesn't run Thrust on mobile so filter those out as well
-  # DVS doesn't have PASCAL configs at the moment
-  ARCH_NEG_FILTER += 20 21 32 37 53 60
-else
-  # If building for ARMv7 (32-bit ARM), build only mobile SASS since no dGPU+ARM32 are supported anymore
-  ifeq ($(TARGET_ARCH),ARMv7)
-    ARCH_FILTER = 32 53 62
-  endif
-  # If its androideabi, we know its mobile, so can target specific SASS
-  ifeq ($(OS),Linux)
-    ifeq ($(ABITYPE), androideabi)
-     ARCH_FILTER = 32 53 62
-     ifeq ($(THRUST_TEST),1)
-       NVCC_OPTIONS += -include "$(ROOTDIR)/cuda/tools/demangler/demangler.h"
-       LIBRARIES += demangler
-     endif
-    endif
-  endif
-endif
-
 # Add -mthumb for Linux on ARM to work around bug in arm cross compiler from p4
 ifeq ($(TARGET_ARCH),ARMv7)
   ifneq ($(HOST_ARCH),ARMv7)

--- a/testing/cuda/adjacent_difference.mk
+++ b/testing/cuda/adjacent_difference.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/complex.mk
+++ b/testing/cuda/complex.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/copy.mk
+++ b/testing/cuda/copy.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/copy_if.mk
+++ b/testing/cuda/copy_if.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/count.mk
+++ b/testing/cuda/count.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/cudart.mk
+++ b/testing/cuda/cudart.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/equal.mk
+++ b/testing/cuda/equal.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/fill.mk
+++ b/testing/cuda/fill.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/find.mk
+++ b/testing/cuda/find.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/for_each.mk
+++ b/testing/cuda/for_each.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/gather.mk
+++ b/testing/cuda/gather.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/generate.mk
+++ b/testing/cuda/generate.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/inner_product.mk
+++ b/testing/cuda/inner_product.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/is_partitioned.mk
+++ b/testing/cuda/is_partitioned.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/is_sorted.mk
+++ b/testing/cuda/is_sorted.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/is_sorted_until.mk
+++ b/testing/cuda/is_sorted_until.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/logical.mk
+++ b/testing/cuda/logical.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/max_element.mk
+++ b/testing/cuda/max_element.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/memory.mk
+++ b/testing/cuda/memory.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/merge.mk
+++ b/testing/cuda/merge.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/merge_by_key.mk
+++ b/testing/cuda/merge_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/merge_sort.mk
+++ b/testing/cuda/merge_sort.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/min_element.mk
+++ b/testing/cuda/min_element.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/minmax_element.mk
+++ b/testing/cuda/minmax_element.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/mismatch.mk
+++ b/testing/cuda/mismatch.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/pair_sort.mk
+++ b/testing/cuda/pair_sort.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/pair_sort_by_key.mk
+++ b/testing/cuda/pair_sort_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/partition.mk
+++ b/testing/cuda/partition.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/partition_point.mk
+++ b/testing/cuda/partition_point.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/pinned_allocator.mk
+++ b/testing/cuda/pinned_allocator.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/reduce.mk
+++ b/testing/cuda/reduce.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/reduce_by_key.mk
+++ b/testing/cuda/reduce_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/remove.mk
+++ b/testing/cuda/remove.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/replace.mk
+++ b/testing/cuda/replace.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/reverse.mk
+++ b/testing/cuda/reverse.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/scan.mk
+++ b/testing/cuda/scan.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/scan_by_key.mk
+++ b/testing/cuda/scan_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/scatter.mk
+++ b/testing/cuda/scatter.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/sequence.mk
+++ b/testing/cuda/sequence.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_difference.mk
+++ b/testing/cuda/set_difference.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_difference_by_key.mk
+++ b/testing/cuda/set_difference_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_intersection.mk
+++ b/testing/cuda/set_intersection.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_intersection_by_key.mk
+++ b/testing/cuda/set_intersection_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_symmetric_difference.mk
+++ b/testing/cuda/set_symmetric_difference.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_symmetric_difference_by_key.mk
+++ b/testing/cuda/set_symmetric_difference_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_union.mk
+++ b/testing/cuda/set_union.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/set_union_by_key.mk
+++ b/testing/cuda/set_union_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/sort.mk
+++ b/testing/cuda/sort.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/sort_by_key.mk
+++ b/testing/cuda/sort_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/swap_ranges.mk
+++ b/testing/cuda/swap_ranges.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/tabulate.mk
+++ b/testing/cuda/tabulate.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/transform.mk
+++ b/testing/cuda/transform.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/transform_reduce.mk
+++ b/testing/cuda/transform_reduce.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/transform_scan.mk
+++ b/testing/cuda/transform_scan.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/uninitialized_copy.mk
+++ b/testing/cuda/uninitialized_copy.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/uninitialized_fill.mk
+++ b/testing/cuda/uninitialized_fill.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/unique.mk
+++ b/testing/cuda/unique.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/cuda/unique_by_key.mk
+++ b/testing/cuda/unique_by_key.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true


### PR DESCRIPTION
- Build CUDA-specific tests with `-rdc=true`; they test device-side launch,
  which needs `-rdc=true` (today, the tests fallback to invoking the serial
  algorithms on the device, which makes them slow).
- Remove old logic disabling codegen for random architectures.
- Re-enable rounding in `bench.cu`.

Bug 2808654