### PR TITLE
Stop specifying the minimum blocks `__launch_bounds__` parameter

### DIFF
--- a/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/system/cuda/detail/adjacent_difference.h
@@ -63,16 +63,14 @@ namespace __adjacent_difference {
             int                      _ITEMS_PER_THREAD = 1,
             cub::BlockLoadAlgorithm  _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier   _LOAD_MODIFIER    = cub::LOAD_DEFAULT,
-            cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT,
-            int                      _MIN_BLOCKS       = 1>
+            cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT>
   struct PtxPolicy
   {
     enum
     {
       BLOCK_THREADS    = _BLOCK_THREADS,
       ITEMS_PER_THREAD = _ITEMS_PER_THREAD,
-      ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD,
-      MIN_BLOCKS       = _MIN_BLOCKS
+      ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD
     };
 
     static const cub::BlockLoadAlgorithm  LOAD_ALGORITHM  = _LOAD_ALGORITHM;

--- a/thrust/system/cuda/detail/binary_search.h
+++ b/thrust/system/cuda/detail/binary_search.h
@@ -92,7 +92,7 @@ namespace __binary_search {
     typedef typename iterator_traits<NeedlesIt>::value_type T;
 
     template <class It, class CompareOp>
-    THRUST_DEVICE_FUNCTION bool 
+    THRUST_DEVICE_FUNCTION bool
     operator()(It begin, It end, T const& value, CompareOp comp)
     {
       HaystackIt iter = system::detail::generic::scalar::lower_bound(begin,
@@ -110,7 +110,7 @@ namespace __binary_search {
             class KeysIt2,
             class Size,
             class BinaryPred>
-  THRUST_DEVICE_FUNCTION Size 
+  THRUST_DEVICE_FUNCTION Size
   merge_path(KeysIt1    keys1,
              KeysIt2    keys2,
              Size       keys1_count,
@@ -143,7 +143,7 @@ namespace __binary_search {
   }
 
   template <class It, class T2, class CompareOp, int ITEMS_PER_THREAD>
-  THRUST_DEVICE_FUNCTION void 
+  THRUST_DEVICE_FUNCTION void
   serial_merge(It  keys_shared,
                int keys1_beg,
                int keys2_beg,
@@ -155,7 +155,7 @@ namespace __binary_search {
   {
     int keys1_end = keys1_beg + keys1_count;
     int keys2_end = keys2_beg + keys2_count;
-    
+
     typedef typename iterator_value<It>::type key_type;
 
     key_type key1 = keys_shared[keys1_beg];
@@ -185,7 +185,6 @@ namespace __binary_search {
 
   template <int                      _BLOCK_THREADS,
             int                      _ITEMS_PER_THREAD = 1,
-            int                      _MIN_BLOCKS       = 1,
             cub::BlockLoadAlgorithm  _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier   _LOAD_MODIFIER    = cub::LOAD_LDG,
             cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT>
@@ -195,19 +194,18 @@ namespace __binary_search {
     {
       BLOCK_THREADS      = _BLOCK_THREADS,
       ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
-      MIN_BLOCKS         = _MIN_BLOCKS,
-      ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD,
+      ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD
     };
 
     static const cub::BlockLoadAlgorithm  LOAD_ALGORITHM  = _LOAD_ALGORITHM;
     static const cub::CacheLoadModifier   LOAD_MODIFIER   = _LOAD_MODIFIER;
     static const cub::BlockStoreAlgorithm STORE_ALGORITHM = _STORE_ALGORITHM;
   };    // PtxPolicy
-  
+
   template <class Arch, class T>
   struct Tuning;
 
-  template<class T>  
+  template<class T>
   struct Tuning<sm30,T>
   {
     enum
@@ -218,13 +216,12 @@ namespace __binary_search {
 
     typedef PtxPolicy<128,
                       ITEMS_PER_THREAD,
-                      1,
                       cub::BLOCK_LOAD_WARP_TRANSPOSE,
                       cub::LOAD_LDG,
                       cub::BLOCK_STORE_TRANSPOSE>
         type;
   };
-  
+
   template<class T>
   struct Tuning<sm52,T>
   {
@@ -238,13 +235,12 @@ namespace __binary_search {
 
     typedef PtxPolicy<128,
                       ITEMS_PER_THREAD,
-                      1,
                       cub::BLOCK_LOAD_WARP_TRANSPOSE,
                       cub::LOAD_LDG,
                       cub::BLOCK_STORE_WARP_TRANSPOSE>
         type;
   };
-  
+
   template <class NeedlesIt,
             class HaystackIt,
             class Size,
@@ -429,7 +425,7 @@ namespace __binary_search {
         needle_type needles_loc[ITEMS_PER_THREAD];
         BlockLoadNeedles(storage.load_needles)
             .Load(needles_load_it + tile_base, needles_loc, num_remaining);
-       
+
 #ifdef BS_SIMPLE
 
         result_type results_loc[ITEMS_PER_THREAD];
@@ -499,7 +495,7 @@ namespace __binary_search {
                         needles_loc[ITEM],
                         compare_op);
         }
-        
+
         sync_threadblock();
 
         result_type results_loc[ITEMS_PER_THREAD];
@@ -627,7 +623,7 @@ namespace __binary_search {
               result,
               compare_op,
               search_op);
-    
+
     CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());
 
     return status;
@@ -692,7 +688,7 @@ namespace __binary_search {
                        stream,
                        debug_sync);
     cuda_cub::throw_on_error(status, "binary_search: failed on 2nt call");
-    
+
     status = cuda_cub::synchronize(policy);
     cuda_cub::throw_on_error(status, "binary_search: failed to synchronize");
 

--- a/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/system/cuda/detail/copy_if.h
@@ -69,7 +69,6 @@ namespace __copy_if {
 
   template <int                     _BLOCK_THREADS,
             int                     _ITEMS_PER_THREAD = 1,
-            int                     _MIN_BLOCKS       = 1,
             cub::BlockLoadAlgorithm _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier  _LOAD_MODIFIER    = cub::LOAD_LDG,
             cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS>
@@ -79,7 +78,6 @@ namespace __copy_if {
     {
       BLOCK_THREADS      = _BLOCK_THREADS,
       ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
-      MIN_BLOCKS         = _MIN_BLOCKS,
       ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD,
     };
     static const cub::BlockLoadAlgorithm LOAD_ALGORITHM = _LOAD_ALGORITHM;
@@ -103,7 +101,6 @@ namespace __copy_if {
 
     typedef PtxPolicy<128,
                       ITEMS_PER_THREAD,
-                      1,
                       cub::BLOCK_LOAD_WARP_TRANSPOSE,
                       cub::LOAD_LDG,
                       cub::BLOCK_SCAN_WARP_SCANS>
@@ -124,7 +121,6 @@ namespace __copy_if {
 
     typedef PtxPolicy<128,
                       ITEMS_PER_THREAD,
-                      1,
                       cub::BLOCK_LOAD_WARP_TRANSPOSE,
                       cub::LOAD_LDG,
                       cub::BLOCK_SCAN_WARP_SCANS>
@@ -144,7 +140,6 @@ namespace __copy_if {
 
     typedef PtxPolicy<128,
                       ITEMS_PER_THREAD,
-                      1,
                       cub::BLOCK_LOAD_WARP_TRANSPOSE,
                       cub::LOAD_DEFAULT,
                       cub::BLOCK_SCAN_WARP_SCANS>

--- a/thrust/system/cuda/detail/core/agent_launcher.h
+++ b/thrust/system/cuda/detail/core/agent_launcher.h
@@ -51,7 +51,7 @@ namespace core {
 #if 0
   template <class Agent, class... Args>
   void __global__
-  __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS,Agent::ptx_plan::MIN_BLOCKS)
+  __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
       _kernel_agent(Args... args)
   {
     extern __shared__ char shmem[];
@@ -59,105 +59,105 @@ namespace core {
   }
 #else
   template <class Agent, class _0>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, shmem);
   }
   template <class Agent, class _0, class _1>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, shmem);
   }
   template <class Agent, class _0, class _1, class _2>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, xB, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB, class _xC>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB, _xC xC)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, xB, xC, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB, class _xC, class _xD>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB, _xC xC, _xD xD)
   {
     extern __shared__ char shmem[];
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, xB, xC, xD, shmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB, class _xC, class _xD, class _xE>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent(_0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB, _xC xC, _xD xD, _xE xE)
   {
     extern __shared__ char shmem[];
@@ -171,7 +171,7 @@ namespace core {
 #if 0
   template <class Agent, class... Args>
   void __global__
-  __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS,Agent::ptx_plan::MIN_BLOCKS)
+  __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
       _kernel_agent_vshmem(char* vshmem, Args... args)
   {
     extern __shared__ char shmem[];
@@ -180,7 +180,7 @@ namespace core {
   }
 #else
   template <class Agent, class _0>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0)
   {
     extern __shared__ char shmem[];
@@ -188,7 +188,7 @@ namespace core {
     Agent::entry(x0, vshmem);
   }
   template <class Agent, class _0, class _1>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1)
   {
     extern __shared__ char shmem[];
@@ -196,7 +196,7 @@ namespace core {
     Agent::entry(x0, x1, vshmem);
   }
   template <class Agent, class _0, class _1, class _2>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2)
   {
     extern __shared__ char shmem[];
@@ -204,7 +204,7 @@ namespace core {
     Agent::entry(x0, x1, x2, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3)
   {
     extern __shared__ char shmem[];
@@ -212,7 +212,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4)
   {
     extern __shared__ char shmem[];
@@ -220,7 +220,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5)
   {
     extern __shared__ char shmem[];
@@ -228,7 +228,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6)
   {
     extern __shared__ char shmem[];
@@ -236,7 +236,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7)
   {
     extern __shared__ char shmem[];
@@ -244,7 +244,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8)
   {
     extern __shared__ char shmem[];
@@ -252,7 +252,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9)
   {
     extern __shared__ char shmem[];
@@ -260,7 +260,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA)
   {
     extern __shared__ char shmem[];
@@ -268,7 +268,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB)
   {
     extern __shared__ char shmem[];
@@ -276,7 +276,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, xB, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB, class _xC>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB, _xC xC)
   {
     extern __shared__ char shmem[];
@@ -284,7 +284,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, xB, xC, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB, class _xC, class _xD>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB, _xC xC, _xD xD)
   {
     extern __shared__ char shmem[];
@@ -292,7 +292,7 @@ namespace core {
     Agent::entry(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xA, xB, xC, xD, vshmem);
   }
   template <class Agent, class _0, class _1, class _2, class _3, class _4, class _5, class _6, class _7, class _8, class _9, class _xA, class _xB, class _xC, class _xD, class _xE>
-  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS, Agent::ptx_plan::MIN_BLOCKS)
+  void __global__ __launch_bounds__(Agent::ptx_plan::BLOCK_THREADS)
   _kernel_agent_vshmem(char* vshmem, _0 x0, _1 x1, _2 x2, _3 x3, _4 x4, _5 x5, _6 x6, _7 x7, _8 x8, _9 x9, _xA xA, _xB xB, _xC xC, _xD xD, _xE xE)
   {
     extern __shared__ char shmem[];

--- a/thrust/system/cuda/detail/merge.h
+++ b/thrust/system/cuda/detail/merge.h
@@ -129,15 +129,13 @@ namespace __merge {
             int                      _ITEMS_PER_THREAD = 1,
             cub::BlockLoadAlgorithm  _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier   _LOAD_MODIFIER    = cub::LOAD_LDG,
-            cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT,
-            int                      _MIN_BLOCKS       = 1>
+            cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT>
   struct PtxPolicy
   {
     enum
     {
       BLOCK_THREADS      = _BLOCK_THREADS,
       ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
-      MIN_BLOCKS         = _MIN_BLOCKS,
       ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD,
     };
 

--- a/thrust/system/cuda/detail/parallel_for.h
+++ b/thrust/system/cuda/detail/parallel_for.h
@@ -43,8 +43,7 @@ namespace cuda_cub {
 namespace __parallel_for {
 
   template <int _BLOCK_THREADS,
-            int _ITEMS_PER_THREAD = 1,
-            int _MIN_BLOCKS       = 1>
+            int _ITEMS_PER_THREAD = 1>
   struct PtxPolicy
   {
     enum
@@ -52,7 +51,6 @@ namespace __parallel_for {
       BLOCK_THREADS    = _BLOCK_THREADS,
       ITEMS_PER_THREAD = _ITEMS_PER_THREAD,
       ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD,
-      MIN_BLOCKS       = _MIN_BLOCKS
     };
   };    // struct PtxPolicy
 
@@ -146,7 +144,7 @@ namespace __parallel_for {
   }
 }    // __parallel_for
 
-__thrust_exec_check_disable__ 
+__thrust_exec_check_disable__
 template <class Derived,
           class F,
           class Size>

--- a/thrust/system/cuda/detail/partition.h
+++ b/thrust/system/cuda/detail/partition.h
@@ -50,7 +50,6 @@ namespace __partition {
 
   template <int                     _BLOCK_THREADS,
             int                     _ITEMS_PER_THREAD = 1,
-            int                     _MIN_BLOCKS       = 1,
             cub::BlockLoadAlgorithm _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier  _LOAD_MODIFIER    = cub::LOAD_LDG,
             cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS>
@@ -60,8 +59,7 @@ namespace __partition {
     {
       BLOCK_THREADS      = _BLOCK_THREADS,
       ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
-      MIN_BLOCKS         = _MIN_BLOCKS,
-      ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD,
+      ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD
     };
     static const cub::BlockLoadAlgorithm LOAD_ALGORITHM = _LOAD_ALGORITHM;
     static const cub::CacheLoadModifier  LOAD_MODIFIER  = _LOAD_MODIFIER;
@@ -84,7 +82,6 @@ namespace __partition {
 
     typedef PtxPolicy<128,
                       ITEMS_PER_THREAD,
-                      1,
                       cub::BLOCK_LOAD_WARP_TRANSPOSE,
                       cub::LOAD_LDG,
                       cub::BLOCK_SCAN_WARP_SCANS>
@@ -104,7 +101,6 @@ namespace __partition {
 
     typedef PtxPolicy<128,
                       ITEMS_PER_THREAD,
-                      1,
                       cub::BLOCK_LOAD_WARP_TRANSPOSE,
                       cub::LOAD_DEFAULT,
                       cub::BLOCK_SCAN_WARP_SCANS>

--- a/thrust/system/cuda/detail/reduce.h
+++ b/thrust/system/cuda/detail/reduce.h
@@ -76,8 +76,7 @@ namespace __reduce {
             int                       _VECTOR_LOAD_LENGTH = 1,
             cub::BlockReduceAlgorithm _BLOCK_ALGORITHM    = cub::BLOCK_REDUCE_RAKING,
             cub::CacheLoadModifier    _LOAD_MODIFIER      = cub::LOAD_DEFAULT,
-            cub::GridMappingStrategy  _GRID_MAPPING       = cub::GRID_MAPPING_DYNAMIC,
-            int                       _MIN_BLOCKS         = 1>
+            cub::GridMappingStrategy  _GRID_MAPPING       = cub::GRID_MAPPING_DYNAMIC>
   struct PtxPolicy
   {
     enum
@@ -85,7 +84,6 @@ namespace __reduce {
       BLOCK_THREADS      = _BLOCK_THREADS,
       ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
       VECTOR_LOAD_LENGTH = _VECTOR_LOAD_LENGTH,
-      MIN_BLOCKS         = _MIN_BLOCKS,
       ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD
     };
 

--- a/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/system/cuda/detail/reduce_by_key.h
@@ -78,16 +78,14 @@ namespace __reduce_by_key {
             int                     _ITEMS_PER_THREAD = 1,
             cub::BlockLoadAlgorithm _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier  _LOAD_MODIFIER    = cub::LOAD_DEFAULT,
-            cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS,
-            int                     _MIN_BLOCKS       = 1>
+            cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS>
   struct PtxPolicy
   {
     enum
     {
       BLOCK_THREADS    = _BLOCK_THREADS,
       ITEMS_PER_THREAD = _ITEMS_PER_THREAD,
-      ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD,
-      MIN_BLOCKS       = _MIN_BLOCKS
+      ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD
     };
 
     static const cub::BlockLoadAlgorithm LOAD_ALGORITHM = _LOAD_ALGORITHM;

--- a/thrust/system/cuda/detail/scan.h
+++ b/thrust/system/cuda/detail/scan.h
@@ -85,8 +85,7 @@ namespace __scan {
             cub::BlockLoadAlgorithm  _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier   _LOAD_MODIFIER    = cub::LOAD_DEFAULT,
             cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT,
-            cub::BlockScanAlgorithm  _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS,
-            int                      _MIN_BLOCKS       = 1>
+            cub::BlockScanAlgorithm  _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS>
   struct PtxPolicy
   {
     enum
@@ -94,7 +93,6 @@ namespace __scan {
       BLOCK_THREADS    = _BLOCK_THREADS,
       ITEMS_PER_THREAD = _ITEMS_PER_THREAD,
       ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD,
-      MIN_BLOCKS       = _MIN_BLOCKS
     };
 
     static const cub::BlockLoadAlgorithm  LOAD_ALGORITHM  = _LOAD_ALGORITHM;

--- a/thrust/system/cuda/detail/sort.h
+++ b/thrust/system/cuda/detail/sort.h
@@ -132,15 +132,13 @@ namespace __merge_sort {
             int                      _ITEMS_PER_THREAD = 1,
             cub::BlockLoadAlgorithm  _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier   _LOAD_MODIFIER    = cub::LOAD_LDG,
-            cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT,
-            int                      _MIN_BLOCKS       = 1>
+            cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT>
   struct PtxPolicy
   {
     enum
     {
       BLOCK_THREADS      = _BLOCK_THREADS,
       ITEMS_PER_THREAD   = _ITEMS_PER_THREAD,
-      MIN_BLOCKS         = _MIN_BLOCKS,
       ITEMS_PER_TILE     = _BLOCK_THREADS * _ITEMS_PER_THREAD,
     };
 

--- a/thrust/system/cuda/detail/unique.h
+++ b/thrust/system/cuda/detail/unique.h
@@ -77,15 +77,13 @@ namespace __unique {
             int                     _ITEMS_PER_THREAD = 1,
             cub::BlockLoadAlgorithm _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier  _LOAD_MODIFIER    = cub::LOAD_LDG,
-            cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS,
-            int                     _MIN_BLOCKS       = 1>
+            cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS>
   struct PtxPolicy
   {
     enum
     {
       BLOCK_THREADS    = _BLOCK_THREADS,
       ITEMS_PER_THREAD = _ITEMS_PER_THREAD,
-      MIN_BLOCKS       = _MIN_BLOCKS,
       ITEMS_PER_TILE   = _BLOCK_THREADS * _ITEMS_PER_THREAD,
     };
     static const cub::BlockLoadAlgorithm LOAD_ALGORITHM = _LOAD_ALGORITHM;

--- a/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/system/cuda/detail/unique_by_key.h
@@ -81,15 +81,13 @@ namespace __unique_by_key {
             int                     _ITEMS_PER_THREAD = 1,
             cub::BlockLoadAlgorithm _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
             cub::CacheLoadModifier  _LOAD_MODIFIER    = cub::LOAD_LDG,
-            cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS,
-            int                     _MIN_BLOCKS       = 1>
+            cub::BlockScanAlgorithm _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS>
   struct PtxPolicy
   {
     enum
     {
       BLOCK_THREADS    = _BLOCK_THREADS,
       ITEMS_PER_THREAD = _ITEMS_PER_THREAD,
-      MIN_BLOCKS       = _MIN_BLOCKS,
       ITEMS_PER_TILE   = _BLOCK_THREADS * _ITEMS_PER_THREAD,
     };
     static const cub::BlockLoadAlgorithm LOAD_ALGORITHM = _LOAD_ALGORITHM;


### PR DESCRIPTION
It messes up register allocation and increases register pressure, and we don't
actually know at compile time how many blocks we will use (aside from single
tile kernels).

For inclusive scan on 16-bit, the current launch bounds annotation tells the compiler that there are 128 threads per block, and only 1 block per SM. On GV100, this means the compiler is free to use up to 255 registers without worrying about occupancy. A compiler change is pushing the per-thread register usage from 39 to 57 registers. Even though the compiler is able to still schedule the kernel using 39 registers without spills, the launch_bounds annotation is telling it not to bother because there are only 4 warps per SM.

However, the kernel is actually executed with many blocks per SM, causing occupancy-related performance issues. See #10 for some results.

The launch bounds are coming from scan.h in THRUST:

```
  template <int                      _BLOCK_THREADS,
            int                      _ITEMS_PER_THREAD = 1,
            cub::BlockLoadAlgorithm  _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
            cub::CacheLoadModifier   _LOAD_MODIFIER    = cub::LOAD_DEFAULT,
            cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT,
            cub::BlockScanAlgorithm  _SCAN_ALGORITHM   = cub::BLOCK_SCAN_WARP_SCANS,
            int                      _MIN_BLOCKS       = 1>
  struct PtxPolicy
```

Empirically, setting `_MIN_BLOCKS` to 12 constrains the compiler to use only 40 registers, which recovers the performance (and occupancy).

```
method=[ _ZN6thrust8cuda_cub4core13_kernel_agentINS0_6__scan9ScanAgentINS_6detail15normal_iteratorINS_10device_ptrIsEEEES9_NS_4plusIsEEisNS5_17integral_constantIbLb1EEEEES9_S9_SB_iN3cub13ScanTileStateIsLb1EEENS3_9DoNothingIsEEEEvT0_T1_T2_T3_T4_T5_ ] gputime=[ 378.016 ] cputime=[ 3.122 ] gridsize=[ 21846, 1, 1 ] threadblocksize=[ 128, 1, 1 ] regperthread=[ 40 ] occupancy=[ 0.750 ]
```

Note that the perf is actually slightly better than the baseline run without the compiler change.

[Internal CI Job](http://ausdvs.nvidia.com/Build_Results?virtualId=1000575211&which_page=current_build)

Bug 2826490

Reviewed-by: Michał 'Griwes' Dominiak <griwes@griwes.info>