### PR TITLE
Fix zero size allocation in new_delete_resource

### DIFF
--- a/testing/mr_new.cu
+++ b/testing/mr_new.cu
@@ -33,4 +33,13 @@ void TestNewDeleteResourceAlignedAllocation()
         }
     }
 }
+
+void TestNewDeleteResourceEmptyAllocation()
+{
+    thrust::mr::new_delete_resource memres;
+    ASSERT_EQUAL(nullptr, memres.do_allocate(0));
+}
+
 DECLARE_UNITTEST(TestNewDeleteResourceAlignedAllocation);
+DECLARE_UNITTEST(TestNewDeleteResourceEmptyAllocation);
+

--- a/testing/mr_new.cu
+++ b/testing/mr_new.cu
@@ -38,7 +38,10 @@ void TestNewDeleteResourceEmptyAllocation()
 {
     thrust::mr::new_delete_resource memres;
     ASSERT_EQUAL(nullptr, memres.do_allocate(0));
+    memres.do_deallocate(nullptr,0);
 }
+
+
 
 DECLARE_UNITTEST(TestNewDeleteResourceAlignedAllocation);
 DECLARE_UNITTEST(TestNewDeleteResourceEmptyAllocation);

--- a/thrust/mr/new.h
+++ b/thrust/mr/new.h
@@ -69,6 +69,11 @@ public:
         ::operator delete(p, bytes, std::align_val_t(alignment));
 #else
         (void)alignment;
+        
+        // If `p` is null, do nothing
+        if(nullptr == p){
+           return;
+        }
         char * ptr = static_cast<char *>(p);
         // calculate where the offset is stored
         std::size_t * offset = reinterpret_cast<std::size_t *>(ptr + bytes);

--- a/thrust/mr/new.h
+++ b/thrust/mr/new.h
@@ -43,6 +43,10 @@ public:
 #if __cplusplus >= 201703L
         return ::operator new(bytes, std::align_val_t(alignment));
 #else
+        // don't allocate anything if the caller requested zero bytes
+        if(0 == bytes){
+           return nullptr;
+        }
         // allocate memory for bytes, plus potential alignment correction,
         // plus store of the correction offset
         void * p = ::operator new(bytes + alignment + sizeof(std::size_t));


### PR DESCRIPTION
fixes https://github.com/thrust/thrust/issues/1052

I attempted to add a new unit test for this, but I'm not familiar with building/running Thrust's unit tests, so I can't verify if I did it correctly. 