### PR TITLE
More correctly detect the presence of aligned/sized new/delete.

### DIFF
--- a/testing/scan.cu
+++ b/testing/scan.cu
@@ -2,6 +2,7 @@
 #include <thrust/scan.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/retag.h>
 #include <thrust/device_malloc.h>
 #include <thrust/device_free.h>

--- a/thrust/device_new_allocator.h
+++ b/thrust/device_new_allocator.h
@@ -139,6 +139,7 @@ template<typename T>
     inline void deallocate(pointer p, size_type cnt)
     {
       // use "::operator delete" rather than keyword delete
+      (void)cnt;
       device_delete(p);
     } // end deallocate()
 

--- a/thrust/mr/new.h
+++ b/thrust/mr/new.h
@@ -40,7 +40,7 @@ class new_delete_resource THRUST_FINAL : public memory_resource<>
 public:
     void * do_allocate(std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) THRUST_OVERRIDE
     {
-#if __cplusplus >= 201703L
+#if defined(__cpp_aligned_new)
         return ::operator new(bytes, std::align_val_t(alignment));
 #else
         // allocate memory for bytes, plus potential alignment correction,
@@ -61,8 +61,13 @@ public:
 
     void do_deallocate(void * p, std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) THRUST_OVERRIDE
     {
-#if __cplusplus >= 201703L
+#if defined(__cpp_aligned_new)
+# if defined(__cpp_sized_deallocation)
         ::operator delete(p, bytes, std::align_val_t(alignment));
+# else
+        (void)bytes;
+        ::operator delete(p, std::align_val_t(alignment));
+# endif
 #else
         (void)alignment;
         char * ptr = static_cast<char *>(p);


### PR DESCRIPTION
This fixes a problem with the interaction of Clang and libstdc++'s operator new overloads. 

Also do some drive-by fixes to make sure everything compiles cleanly with Clang and C++17.

[Internal bug 2843412.](http://nvbugs.nvidia.com/2843412)
[Internal P4 shelved change.](https://p4sw-swarm.nvidia.com/changes/27995860)

It seems that the issue is caused by libstdc++ using `__cpp_sized_deallocation`, with Clang not predefining it unless requested by a flag (https://releases.llvm.org/3.7.0/tools/clang/docs/ReleaseNotes.html#new-compiler-flags) (why in the world would they do it this particular way, i.e. opt in and not opt out, and why in the world would they _still_ hide it behind an opt-in flag, is completely beyond me).