### PR TITLE
Deprecate C++03, C++11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,13 @@ add_definitions(-DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_${THRUST_DEVICE_SYST
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "The C++ version to be used.")
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Ignore when building thrust itself on deprecated C++ standards
+add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT)
+add_definitions(-DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT)
+
 message("-- C++ Standard version: ${CMAKE_CXX_STANDARD}")
+
+set(CUB_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/dependencies/cub")
 
 if ("CUDA" STREQUAL "${THRUST_DEVICE_SYSTEM}")
   if (NOT "${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "")
@@ -355,7 +361,7 @@ endforeach ()
 add_library(header-test OBJECT ${THRUST_HEADER_TEST_SOURCES})
 target_include_directories(
   header-test
-  PUBLIC ${PROJECT_SOURCE_DIR}
+  PUBLIC ${PROJECT_SOURCE_DIR} ${CUB_INCLUDE_DIR}
 )
 
 include(CTest)
@@ -383,7 +389,7 @@ endif ()
 add_library(thrust_testframework STATIC ${THRUST_TESTFRAMEWORK_FILES})
 target_include_directories(
   thrust_testframework
-  PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/dependencies/cub
+  PUBLIC ${PROJECT_SOURCE_DIR} ${CUB_INCLUDE_DIR}
   PRIVATE ${PROJECT_SOURCE_DIR}/testing
 )
 
@@ -491,7 +497,7 @@ foreach (THRUST_TEST_SOURCE IN LISTS THRUST_TESTS)
 
   target_include_directories(
     ${THRUST_TEST}
-    PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/dependencies/cub/cub
+    PUBLIC ${PROJECT_SOURCE_DIR} ${CUB_INCLUDE_DIR}
     PRIVATE ${PROJECT_SOURCE_DIR}/testing
   )
 
@@ -518,7 +524,7 @@ foreach (THRUST_TEST_SOURCE IN LISTS THRUST_TESTS)
 
     target_include_directories(
       ${THRUST_TEST_RDC}
-      PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/dependencies/cub/cub
+      PUBLIC ${PROJECT_SOURCE_DIR} ${CUB_INCLUDE_DIR}
       PRIVATE ${PROJECT_SOURCE_DIR}/testing
     )
 
@@ -617,7 +623,7 @@ foreach (THRUST_EXAMPLE_SOURCE IN LISTS THRUST_EXAMPLES)
 
   target_include_directories(
     ${THRUST_EXAMPLE}
-    PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/dependencies/cub/cub
+    PUBLIC ${PROJECT_SOURCE_DIR} ${CUB_INCLUDE_DIR}
     PRIVATE ${PROJECT_SOURCE_DIR}/examples
   )
 
@@ -640,7 +646,7 @@ foreach (THRUST_EXAMPLE_SOURCE IN LISTS THRUST_EXAMPLES)
 
     target_include_directories(
       ${THRUST_EXAMPLE_RDC}
-      PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/dependencies/cub/cub
+      PUBLIC ${PROJECT_SOURCE_DIR} ${CUB_INCLUDE_DIR}
       PRIVATE ${PROJECT_SOURCE_DIR}/examples
     )
 

--- a/thrust/detail/config/compiler.h
+++ b/thrust/detail/config/compiler.h
@@ -181,14 +181,4 @@
   THRUST_DISABLE_CLANG_AND_GCC_INITIALIZER_REORDERING_WARNING_END             \
   /**/
 
-// TODO we should move the definition of THRUST_DEPRECATED out of this logic
-#if   THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
-  #define THRUST_DEPRECATED __declspec(deprecated)
-#elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-  #define THRUST_DEPRECATED __attribute__((deprecated))
-#elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
-  #define THRUST_DEPRECATED __attribute__((deprecated))
-#else
-  #define THRUST_DEPRECATED
-#endif
 

--- a/thrust/detail/config/config.h
+++ b/thrust/detail/config/config.h
@@ -26,6 +26,7 @@
 #include <thrust/detail/config/compiler.h>
 #include <thrust/detail/config/cpp_dialect.h>
 #include <thrust/detail/config/cpp_compatibility.h>
+#include <thrust/detail/config/deprecated.h>
 // host_system.h & device_system.h must be #included as early as possible
 // because other config headers depend on it
 #include <thrust/detail/config/host_system.h>

--- a/thrust/detail/config/cpp_dialect.h
+++ b/thrust/detail/config/cpp_dialect.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 NVIDIA Corporation
+ *  Copyright 2020 NVIDIA Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,19 +14,79 @@
  *  limitations under the License.
  */
 
+/*! \file cpp_dialect.h
+ *  \brief Detect the version of the C++ standard used by the compiler.
+ */
+
 #pragma once
 
-#if   __cplusplus < 201103L
-  #define THRUST_CPP03
-  #define THRUST_CPP_DIALECT 2003
-#elif __cplusplus < 201402L
-  #define THRUST_CPP11
-  #define THRUST_CPP_DIALECT 2011
-#elif __cplusplus < 201703L
-  #define THRUST_CPP14
-  #define THRUST_CPP_DIALECT 2014
-#else
-  #define THRUST_CPP17
-  #define THRUST_CPP_DIALECT 2017
-#endif
+#include <thrust/detail/config/deprecated.h>
+#include <thrust/version.h> // for THRUST_..._NS macros
 
+#ifndef THRUST_CPP_DIALECT
+
+// MSVC prior to 2015U3 does not expose the C++ dialect and is not supported.
+// This is a hard error.
+#  ifndef THRUST_IGNORE_DEPRECATED_CPP_DIALECT
+#    if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190024210
+#      error "MSVC < 2015 Update 3 is not supported by Thrust."
+#    endif
+#  endif
+
+// MSVC does not define __cplusplus correctly. _MSVC_LANG is used instead
+// (MSVC 2015U3+ only)
+#  ifdef _MSVC_LANG
+#    define THRUST___CPLUSPLUS _MSVC_LANG
+#  else
+#    define THRUST___CPLUSPLUS __cplusplus
+#  endif
+
+// Detect current standard:
+#  if THRUST___CPLUSPLUS < 201103L
+#    define THRUST_CPP_DIALECT 2003
+#  elif THRUST___CPLUSPLUS < 201402L
+#    define THRUST_CPP_DIALECT 2011
+#  elif THRUST___CPLUSPLUS < 201703L
+#    define THRUST_CPP_DIALECT 2014
+#  elif THRUST___CPLUSPLUS == 201703L
+#    define THRUST_CPP_DIALECT 2017
+#  elif THRUST___CPLUSPLUS > 201703L // unknown, but is higher than 2017.
+#    define THRUST_CPP_DIALECT 2020
+#  endif
+
+#  undef THRUST___CPLUSPLUS // cleanup
+
+#endif // THRUST_CPP_DIALECT
+
+THRUST_BEGIN_NS
+
+namespace config
+{
+
+// Warn for deprecated dialects. Unused function, only compiled so that
+// deprecated classes are used.
+inline void CheckCppDialect()
+{
+  // Users may define this to silent the deprecated dialect warnings:
+#ifndef THRUST_IGNORE_DEPRECATED_CPP_DIALECT
+
+#  if THRUST_CPP_DIALECT <= 2003
+
+  struct THRUST_DEPRECATED Cpp03_is_deprecated_in_thrust {};
+  Cpp03_is_deprecated_in_thrust x;
+  (void)x;
+
+#  elif THRUST_CPP_DIALECT <= 2011
+
+  struct THRUST_DEPRECATED Cpp11_is_deprecated_in_thrust {};
+  Cpp11_is_deprecated_in_thrust x;
+  (void)x;
+
+#  endif
+
+#endif
+}
+
+} // namespace config
+
+THRUST_END_NS

--- a/thrust/detail/config/deprecated.h
+++ b/thrust/detail/config/deprecated.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2018-2020 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*! \file deprecated.h
+ *  \brief Defines the THRUST_DEPRECATED macro
+ */
+
+#pragma once
+
+#include <thrust/detail/config/compiler.h>
+
+#if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
+#  define THRUST_DEPRECATED __declspec(deprecated)
+#elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
+#  define THRUST_DEPRECATED __attribute__((deprecated))
+#elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
+#  define THRUST_DEPRECATED __attribute__((deprecated))
+#else
+#  define THRUST_DEPRECATED
+#endif


### PR DESCRIPTION
A deprecation warning is emitted when compiling thrust code against
C++03 and C++11. This warning may be disabled by defining
THRUST_IGNORE_DEPRECATED_CPP_DIALECT.

This effectively deprecates GCC < 5.x and MSVC 2015.