### PR TITLE
Add managed_pointer that is compatible with STL.

### DIFF
--- a/testing/cuda/managed_memory_pointer.cu
+++ b/testing/cuda/managed_memory_pointer.cu
@@ -1,0 +1,141 @@
+#include <thrust/detail/config.h>
+
+#if THRUST_CPP_DIALECT >= 2011
+
+#  include <unittest/unittest.h>
+
+#  include <thrust/allocate_unique.h>
+#  include <thrust/memory/detail/device_system_resource.h>
+#  include <thrust/mr/allocator.h>
+#  include <thrust/type_traits/is_contiguous_iterator.h>
+
+#  include <numeric>
+#  include <vector>
+
+namespace
+{
+
+template <typename T>
+using allocator =
+  thrust::mr::stateless_resource_allocator<T, thrust::universal_memory_resource>;
+
+// The managed_memory_pointer class should be identified as a
+// contiguous_iterator
+THRUST_STATIC_ASSERT(
+  thrust::is_contiguous_iterator<allocator<int>::pointer>::value);
+
+template <typename T>
+struct some_object {
+  some_object(T data)
+      : m_data(data)
+  {}
+
+  void setter(T data) { m_data = data; }
+  T getter() const { return m_data; }
+
+private:
+  T m_data;
+};
+
+} // namespace
+
+template <typename T>
+void TestAllocateUnique()
+{
+  // Simple test to ensure that pointers created with universal_memory_resource
+  // can be dereferenced and used with STL code. This is necessary as some
+  // STL implementations break when using fancy references that overload
+  // `operator&`, so universal_memory_resource uses a special pointer type that
+  // returns regular C++ references that can be safely used host-side.
+
+  // These operations fail to compile with fancy references:
+  auto pRaw = thrust::allocate_unique<T>(allocator<T>{}, 42);
+  auto pObj =
+    thrust::allocate_unique<some_object<T> >(allocator<some_object<T> >{}, 42);
+
+  static_assert(
+    std::is_same<decltype(pRaw.get()),
+                 thrust::system::cuda::detail::managed_memory_pointer<T> >::value,
+    "Unexpected pointer returned from unique_ptr::get.");
+  static_assert(
+    std::is_same<decltype(pObj.get()),
+                 thrust::system::cuda::detail::managed_memory_pointer<
+                   some_object<T> > >::value,
+    "Unexpected pointer returned from unique_ptr::get.");
+
+  ASSERT_EQUAL(*pRaw, T(42));
+  ASSERT_EQUAL(*pRaw.get(), T(42));
+  ASSERT_EQUAL(pObj->getter(), T(42));
+  ASSERT_EQUAL((*pObj).getter(), T(42));
+  ASSERT_EQUAL(pObj.get()->getter(), T(42));
+  ASSERT_EQUAL((*pObj.get()).getter(), T(42));
+}
+DECLARE_GENERIC_UNITTEST(TestAllocateUnique);
+
+template <typename T>
+void TestIterationRaw()
+{
+  auto array = thrust::allocate_unique_n<T>(allocator<T>{}, 6, 42);
+
+  static_assert(
+    std::is_same<decltype(array.get()),
+                 thrust::system::cuda::detail::managed_memory_pointer<T> >::value,
+    "Unexpected pointer returned from unique_ptr::get.");
+
+  for (auto iter = array.get(), end = array.get() + 6; iter < end; ++iter)
+  {
+    ASSERT_EQUAL(*iter, T(42));
+    ASSERT_EQUAL(*iter.get(), T(42));
+  }
+}
+DECLARE_GENERIC_UNITTEST(TestIterationRaw);
+
+template <typename T>
+void TestIterationObj()
+{
+  auto array =
+    thrust::allocate_unique_n<some_object<T> >(allocator<some_object<T> >{},
+                                               6,
+                                               42);
+
+  static_assert(
+    std::is_same<decltype(array.get()),
+                 thrust::system::cuda::detail::managed_memory_pointer<
+                   some_object<T> > >::value,
+    "Unexpected pointer returned from unique_ptr::get.");
+
+  for (auto iter = array.get(), end = array.get() + 6; iter < end; ++iter)
+  {
+    ASSERT_EQUAL(iter->getter(), T(42));
+    ASSERT_EQUAL((*iter).getter(), T(42));
+    ASSERT_EQUAL(iter.get()->getter(), T(42));
+    ASSERT_EQUAL((*iter.get()).getter(), T(42));
+  }
+}
+DECLARE_GENERIC_UNITTEST(TestIterationObj);
+
+template <typename T>
+void TestStdVector()
+{
+  // Verify that a std::vector using the universal allocator will work with
+  // STL algorithms.
+  std::vector<T, allocator<T> > v0;
+
+  static_assert(
+    std::is_same<typename std::decay<decltype(v0)>::type::pointer,
+                 thrust::system::cuda::detail::managed_memory_pointer<
+                   T > >::value,
+    "Unexpected pointer returned from unique_ptr::get.");
+
+  v0.resize(6);
+  std::iota(v0.begin(), v0.end(), 0);
+  ASSERT_EQUAL(v0[0], T(0));
+  ASSERT_EQUAL(v0[1], T(1));
+  ASSERT_EQUAL(v0[2], T(2));
+  ASSERT_EQUAL(v0[3], T(3));
+  ASSERT_EQUAL(v0[4], T(4));
+  ASSERT_EQUAL(v0[5], T(5));
+}
+DECLARE_GENERIC_UNITTEST(TestStdVector);
+
+#endif // C++11

--- a/testing/cuda/managed_memory_pointer.mk
+++ b/testing/cuda/managed_memory_pointer.mk
@@ -1,0 +1,1 @@
+CUDACC_FLAGS += -rdc=true

--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -52,24 +52,27 @@ DECLARE_VECTOR_UNITTEST(TestVectorFrontBack);
 template <class Vector>
 void TestVectorData(void)
 {
+    typedef typename Vector::pointer PointerT;
+    typedef typename Vector::const_pointer PointerConstT;
+
     Vector v(3);
     v[0] = 0; v[1] = 1; v[2] = 2;
 
     ASSERT_EQUAL(0,          *v.data());
     ASSERT_EQUAL(1,          *(v.data() + 1));
     ASSERT_EQUAL(2,          *(v.data() + 2));
-    ASSERT_EQUAL(&v.front(),  v.data());
-    ASSERT_EQUAL(&*v.begin(), v.data());
-    ASSERT_EQUAL(&v[0],       v.data());
+    ASSERT_EQUAL(PointerT(&v.front()),  v.data());
+    ASSERT_EQUAL(PointerT(&*v.begin()), v.data());
+    ASSERT_EQUAL(PointerT(&v[0]),       v.data());
 
     const Vector &c_v = v;
 
     ASSERT_EQUAL(0,            *c_v.data());
     ASSERT_EQUAL(1,            *(c_v.data() + 1));
     ASSERT_EQUAL(2,            *(c_v.data() + 2));
-    ASSERT_EQUAL(&c_v.front(),  c_v.data());
-    ASSERT_EQUAL(&*c_v.begin(), c_v.data());
-    ASSERT_EQUAL(&c_v[0],       c_v.data());
+    ASSERT_EQUAL(PointerConstT(&c_v.front()),  c_v.data());
+    ASSERT_EQUAL(PointerConstT(&*c_v.begin()), c_v.data());
+    ASSERT_EQUAL(PointerConstT(&c_v[0]),       c_v.data());
 }
 DECLARE_VECTOR_UNITTEST(TestVectorData);
 

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -540,7 +540,7 @@ template<typename T, typename Alloc>
     vector_base<T,Alloc>
       ::data(void)
 {
-  return &front();
+  return pointer(&front());
 } // end vector_base::data()
 
 template<typename T, typename Alloc>
@@ -548,7 +548,7 @@ template<typename T, typename Alloc>
     vector_base<T,Alloc>
       ::data(void) const
 {
-  return &front();
+  return const_pointer(&front());
 } // end vector_base::data()
 
 template<typename T, typename Alloc>

--- a/thrust/mr/allocator.h
+++ b/thrust/mr/allocator.h
@@ -22,6 +22,7 @@
 
 #include <limits>
 
+#include <thrust/detail/config/exec_check_disable.h>
 #include <thrust/detail/type_traits/pointer_traits.h>
 
 #include <thrust/mr/detail/config.h>
@@ -93,6 +94,7 @@ public:
      *
      *  \returns the maximum value of \p std::size_t, divided by the size of \p T.
      */
+    __thrust_exec_check_disable__
     __host__ __device__
     size_type max_size() const
     {

--- a/thrust/system/cuda/detail/managed_memory_pointer.h
+++ b/thrust/system/cuda/detail/managed_memory_pointer.h
@@ -1,0 +1,195 @@
+/*
+ *  Copyright 2020 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/pointer.h>
+
+#include <thrust/detail/type_traits.h>
+#include <thrust/system/cuda/detail/execution_policy.h>
+
+namespace thrust
+{
+namespace system
+{
+namespace cuda
+{
+namespace detail
+{
+
+// forward decl for iterator traits:
+template <typename T>
+class managed_memory_pointer;
+
+} // end namespace detail
+} // end namespace cuda
+} // end namespace system
+
+// Specialize iterator traits to define `pointer` to something meaningful.
+template <typename Element, typename Tag, typename Reference>
+struct iterator_traits<thrust::pointer<
+  Element,
+  Tag,
+  Reference,
+  thrust::system::cuda::detail::managed_memory_pointer<Element> > > {
+private:
+  typedef thrust::pointer<
+    Element,
+    Tag,
+    Reference,
+    thrust::system::cuda::detail::managed_memory_pointer<Element> >
+    ptr;
+
+public:
+  typedef typename ptr::iterator_category iterator_category;
+  typedef typename ptr::value_type value_type;
+  typedef typename ptr::difference_type difference_type;
+  typedef Element* pointer;
+  typedef typename ptr::reference reference;
+}; // end iterator_traits
+
+namespace system
+{
+namespace cuda
+{
+namespace detail
+{
+
+/*! A version of thrust::cuda_cub::pointer that uses c++ references instead
+ * of thrust::cuda::reference. This is to allow managed memory pointers to
+ * be used with host-side code in standard libraries that are not compatible
+ * with proxy references.
+ */
+template <typename T>
+class managed_memory_pointer
+    : public thrust::pointer<
+        T,
+        thrust::cuda_cub::tag,
+        typename thrust::detail::add_reference<T>::type,
+        thrust::system::cuda::detail::managed_memory_pointer<T> >
+{
+private:
+  typedef thrust::pointer<
+    T,
+    thrust::cuda_cub::tag,
+    typename thrust::detail::add_reference<T>::type,
+    thrust::system::cuda::detail::managed_memory_pointer<T> >
+    super_t;
+
+public:
+  typedef typename super_t::raw_pointer pointer;
+
+  /*! \p managed_memory_pointer's no-argument constructor initializes its
+   * encapsulated pointer to \c 0.
+   */
+  __host__ __device__ managed_memory_pointer()
+      : super_t()
+  {}
+
+#if THRUST_CPP_DIALECT >= 2011
+  // NOTE: This is needed so that Thrust smart pointers can be used in
+  // `std::unique_ptr`.
+  __host__ __device__ managed_memory_pointer(decltype(nullptr))
+      : super_t(nullptr)
+  {}
+#endif
+
+  /*! This constructor allows construction of a <tt><const T></tt> from a
+   * <tt>T*</tt>.
+   *
+   *  \param ptr A raw pointer to copy from, presumed to point to a location
+   * in memory accessible by the \p cuda system. \tparam OtherT \p OtherT
+   * shall be convertible to \p T.
+   */
+  template <typename OtherT>
+  __host__ __device__ explicit managed_memory_pointer(OtherT* ptr)
+      : super_t(ptr)
+  {}
+
+  /*! This constructor allows construction from another pointer-like object
+   * with related type.
+   *
+   *  \param other The \p OtherPointer to copy.
+   *  \tparam OtherPointer The system tag associated with \p OtherPointer
+   * shall be convertible to \p thrust::system::cuda::tag and its element
+   * type shall be convertible to \p T.
+   */
+  template <typename OtherPointer>
+  __host__ __device__ managed_memory_pointer(
+    const OtherPointer& other,
+    typename thrust::detail::enable_if_pointer_is_convertible<
+      OtherPointer,
+      managed_memory_pointer>::type* = 0)
+      : super_t(other)
+  {}
+
+  /*! This constructor allows construction from another pointer-like object
+   * with \p void type.
+   *
+   *  \param other The \p OtherPointer to copy.
+   *  \tparam OtherPointer The system tag associated with \p OtherPointer
+   * shall be convertible to \p thrust::system::cuda::tag and its element
+   * type shall be \p void.
+   */
+  template <typename OtherPointer>
+  __host__ __device__ explicit managed_memory_pointer(
+    const OtherPointer& other,
+    typename thrust::detail::enable_if_void_pointer_is_system_convertible<
+      OtherPointer,
+      managed_memory_pointer>::type* = 0)
+      : super_t(other)
+  {}
+
+  /*! Assignment operator allows assigning from another pointer-like object
+   * with related type.
+   *
+   *  \param other The other pointer-like object to assign from.
+   *  \tparam OtherPointer The system tag associated with \p OtherPointer
+   * shall be convertible to \p thrust::system::cuda::tag and its element
+   * type shall be convertible to \p T.
+   */
+  template <typename OtherPointer>
+  __host__ __device__ typename thrust::detail::enable_if_pointer_is_convertible<
+    OtherPointer,
+    managed_memory_pointer,
+    managed_memory_pointer&>::type
+  operator=(const OtherPointer& other)
+  {
+    return super_t::operator=(other);
+  }
+
+#if THRUST_CPP_DIALECT >= 2011
+  // NOTE: This is needed so that Thrust smart pointers can be used in
+  // `std::unique_ptr`.
+  __host__ __device__ managed_memory_pointer& operator=(decltype(nullptr))
+  {
+    super_t::operator=(nullptr);
+    return *this;
+  }
+#endif
+
+  __host__ __device__
+  pointer operator->() const
+  {
+    return this->get();
+  }
+
+}; // class managed_memory_pointer
+
+} // namespace detail
+} // namespace cuda
+} // namespace system
+} // namespace thrust

--- a/thrust/system/cuda/memory_resource.h
+++ b/thrust/system/cuda/memory_resource.h
@@ -22,6 +22,7 @@
 
 #include <thrust/mr/memory_resource.h>
 #include <thrust/system/cuda/detail/guarded_cuda_runtime_api.h>
+#include <thrust/system/cuda/detail/managed_memory_pointer.h>
 #include <thrust/system/cuda/pointer.h>
 #include <thrust/system/detail/bad_alloc.h>
 #include <thrust/system/cuda/error.h>
@@ -86,7 +87,7 @@ namespace detail
         thrust::cuda::pointer<void> >
         device_memory_resource;
     typedef detail::cuda_memory_resource<detail::cudaMallocManaged, cudaFree,
-        thrust::cuda::pointer<void> >
+        detail::managed_memory_pointer<void> >
         managed_memory_resource;
     typedef detail::cuda_memory_resource<cudaMallocHost, cudaFreeHost,
         thrust::host_memory_resource::pointer>


### PR DESCRIPTION
The existing `cuda::pointer` uses a fancy reference that overloads
`operator&`, and some STL implementations misbehave when that operator
does not return the actual memory address of the object.

Since universal_memory_resource allocates memory that works on both host
and device, we need to be able to use these types with stl containers,
such as std::vector.

This patch adds a managed_pointer implementation that behaves like
`cuda::pointer`, but returns a regular c++ reference, allowing
the thrust universal allocator to work with STL containers.