### PR TITLE
Remove `__device__` from CUDA MR-based device allocators

### DIFF
--- a/thrust/system/cuda/memory.h
+++ b/thrust/system/cuda/memory.h
@@ -100,13 +100,13 @@ public:
 
   /*! No-argument constructor has no effect.
    */
-  __host__ __device__
+  __host__
   inline allocator() {}
 
   /*! Copy constructor has no effect.
    */
   __host__ __device__
- inline allocator(const allocator & other) : base(other) {}
+  inline allocator(const allocator & other) : base(other) {}
 
   /*! Constructor from other \p allocator has no effect.
    */


### PR DESCRIPTION
This fixes obscure "host function called from host device function" warning that occurs when you use the new Thrust MR-based allocators.