### PR TITLE
Adding CUB Version Check

### DIFF
--- a/thrust/system/cuda/config.h
+++ b/thrust/system/cuda/config.h
@@ -71,3 +71,10 @@
 #define THRUST_CUB_NS_PREFIX namespace thrust {   namespace cuda_cub {
 #define THRUST_CUB_NS_POSTFIX }  }
 
+#ifndef THRUST_IGNORE_CUB_VERSION_CHECK
+#include <thrust/version.h>
+#include <cub/version.cuh>
+#if THRUST_VERSION != CUB_VERSION
+#error The version of CUB in your include path is not compatible with this release of Thrust. Define THRUST_IGNORE_CUB_VERSION_CHECK to ignore this.
+#endif
+#endif


### PR DESCRIPTION
- Added exact version match check of CUB to Thrust (if CUB version is not exactly the same as the Thrust version, a compilation error will occur)
- Added escape hatch preprocessor define to avoid the version checking

Bug 2880957