### PR TITLE
Add `-Werror all-warnings` to nvcc invocations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ foreach (CXX_OPTION IN LISTS THRUST_CXX_WARNINGS)
 endforeach ()
 
 if ("CUDA" STREQUAL "${THRUST_DEVICE_SYSTEM}")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror all-warnings")
   foreach (CXX_OPTION IN LISTS THRUST_CXX_WARNINGS)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=${CXX_OPTION}")
   endforeach ()

--- a/internal/build/common_warnings.mk
+++ b/internal/build/common_warnings.mk
@@ -122,3 +122,6 @@ else ifeq ($(OS),win32)
   CUDACC_FLAGS += -Xcompiler "/wd4146"
 endif
 
+# Promote all NVCC warnings into errors
+CUDACC_FLAGS += -Werror all-warnings
+


### PR DESCRIPTION
Shelve 28189576.