### PR TITLE
Allow replace algorithms with functors with non-const call operators

### DIFF
--- a/thrust/system/cuda/detail/replace.h
+++ b/thrust/system/cuda/detail/replace.h
@@ -64,14 +64,14 @@ namespace cuda_cub {
 
       template<class T>
       OutputType THRUST_DEVICE_FUNCTION
-      operator()(T const &x) const
+      operator()(T const &x)
       {
         return pred(x) ? new_value : x;
       }
 
       template<class T, class P>
       OutputType THRUST_DEVICE_FUNCTION
-      operator()(T const &x, P const& y) const
+      operator()(T const &x, P const& y)
       {
         return pred(y) ? new_value : x;
       }


### PR DESCRIPTION
The CUDA back end for thrust::replace_copy_if would fail to compile if
called with a predicate that had a non-const function call operator.
Fix the problem by changing thrust::cuda_cub::__replace::new_value_if_f's
function call operators to be non-const.  The operators don't need to be
const member functions because there are no const objects of type
new_value_if_f.  Having the operators be const unnecessarily requires
that the function call operator of the embedded predicate be const.