### PR TITLE
execution_policy: Add missing constexpr to par_t constructor

### DIFF
--- a/thrust/system/omp/detail/par.h
+++ b/thrust/system/omp/detail/par.h
@@ -35,7 +35,7 @@ struct par_t : thrust::system::omp::detail::execution_policy<par_t>,
     thrust::system::omp::detail::execution_policy>
 {
   __host__ __device__
-  par_t() : thrust::system::omp::detail::execution_policy<par_t>() {}
+  THRUST_CONSTEXPR par_t() : thrust::system::omp::detail::execution_policy<par_t>() {}
 };
 
 

--- a/thrust/system/tbb/detail/par.h
+++ b/thrust/system/tbb/detail/par.h
@@ -35,7 +35,7 @@ struct par_t : thrust::system::tbb::detail::execution_policy<par_t>,
     thrust::system::tbb::detail::execution_policy>
 {
   __host__ __device__
-  par_t() : thrust::system::tbb::detail::execution_policy<par_t>() {}
+  THRUST_CONSTEXPR par_t() : thrust::system::tbb::detail::execution_policy<par_t>() {}
 };
 
 


### PR DESCRIPTION
Fixes #1093 