### PR TITLE
Fix regression of temporary_allocator with non-CUDA back ends

### DIFF
--- a/thrust/detail/allocator/temporary_allocator.inl
+++ b/thrust/detail/allocator/temporary_allocator.inl
@@ -51,7 +51,7 @@ __host__ __device__
         throw thrust::system::detail::bad_alloc("temporary_buffer::allocate: get_temporary_buffer failed");
       #endif
     } else {
-      #if THRUST_INCLUDE_DEVICE_CODE
+      #if THRUST_INCLUDE_DEVICE_CODE && THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
         thrust::system::cuda::detail::terminate_with_message("temporary_buffer::allocate: get_temporary_buffer failed");
       #endif
     }


### PR DESCRIPTION
A recent cleanup of functions that have different code for host and device
accidentally broke temporary_allocator for non-CUDA back ends.  An #if
condition that protects a piece of code that only works with the CUDA back
end was incorrectly removed.  This fix adds that condition back in.

Fix issue #1101 