### PR TITLE
Opt in to deprecations in DVS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@
 # Makefile for building Thrust unit test driver
 
 # Force C++14 mode. NVCC will ignore it if the host compiler doesn't support it.
-export CXX_STD = c++14
+export CXX_STD := c++14
 
-export VERBOSE = 1
+export CCCL_ENABLE_DEPRECATIONS := 1
+
+export VERBOSE := 1
 
 ifndef PROFILE
   ifdef VULCAN_TOOLKIT_BASE

--- a/internal/build/common_build.mk
+++ b/internal/build/common_build.mk
@@ -1,5 +1,7 @@
 USE_NEW_PROJECT_MK := 1
 
+CCCL_ENABLE_DEPRECATIONS := 1
+
 ifeq ($(OS),Linux)
   LIBRARIES += m
 endif


### PR DESCRIPTION
This won't make a lot of sense without the other part, but this disables adding the macros which opt out of the deprecation warnings to our command line. Note that separately we add them for Thrust/CUB for older compilers (GCC 4.8 and MSVC 2015).