### PR TITLE
Add a missing change that actually fixes the legacy Makefiles to propagate the C++ dialect correctly.

### DIFF
--- a/internal/build/common_detect.mk
+++ b/internal/build/common_detect.mk
@@ -1,3 +1,5 @@
+CXX_STD = c++14
+
 ifeq ($(THRUST_TEST),1)
   include $(ROOTDIR)/build/getprofile.mk
   include $(ROOTDIR)/build/config/$(PROFILE).mk


### PR DESCRIPTION
This is already in Perforce, I must have forgotten to update #1099 before merging it.