### PR TITLE
Make submodule path global

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cub"]
 	path = dependencies/cub
-	url = ../cub.git
+	url = git@github.com:thrust/cub.git


### PR DESCRIPTION
This commit sets `cub` repository as the global cub repository, allowing people with forks to clone and update submodules without failing. This fixes #1119 