### PR TITLE
Don't include `<cub/version.cuh>` directly in the Thrust/CUB version mismatch check because it didn't exist in prior releases.

### DIFF
--- a/thrust/system/cuda/config.h
+++ b/thrust/system/cuda/config.h
@@ -73,7 +73,7 @@
 
 #ifndef THRUST_IGNORE_CUB_VERSION_CHECK
 #include <thrust/version.h>
-#include <cub/version.cuh>
+#include <cub/util_namespace.cuh> // This includes <cub/version.cuh> in newer releases.
 #if THRUST_VERSION != CUB_VERSION
 #error The version of CUB in your include path is not compatible with this release of Thrust. Define THRUST_IGNORE_CUB_VERSION_CHECK to ignore this.
 #endif


### PR DESCRIPTION
Bug 2950372

Related: https://github.com/thrust/cub/pull/24