### PR TITLE
support per-thread default stream

### DIFF
--- a/thrust/system/cuda/detail/util.h
+++ b/thrust/system/cuda/detail/util.h
@@ -43,7 +43,11 @@ inline __host__ __device__
 cudaStream_t
 default_stream()
 {
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  return cudaStreamPerThread;
+#else
   return cudaStreamLegacy;
+#endif
 }
 
 // Fallback implementation of the customization point.


### PR DESCRIPTION
I was trying to get cuDF to use per-thread default stream. It mostly worked, but I was still seeing some stuff happening on the legacy default stream. Finally traced to the `default_stream()` function here. Making the following change got rid of the default stream activities.

This seems like the right thing to do. If someone is trying to use per-thread default stream through compiler flags, it seems wrong for thrust to use the legacy default stream behind the user's back. There might be additional race conditions the user needs to take care of, but at least the thrust code would be doing what the user tells it to do.

See https://github.com/rapidsai/rmm/pull/354 and https://github.com/rapidsai/cudf/pull/4995.