### PR TITLE
Fix the one-policy overload of `thrust::async::copy` to not copy the policy

### DIFF
--- a/thrust/async/copy.h
+++ b/thrust/async/copy.h
@@ -59,7 +59,7 @@ async_copy(
   , "this algorithm is not implemented for the specified system"
   );
   return {};
-} 
+}
 
 } // namespace unimplemented
 
@@ -79,7 +79,7 @@ struct copy_fn final
     thrust::detail::execution_policy_base<FromPolicy> const& from_exec
   , thrust::detail::execution_policy_base<ToPolicy> const&   to_exec
   , ForwardIt&& first, Sentinel&& last
-  , OutputIt&& output 
+  , OutputIt&& output
   )
   // ADL dispatch.
   THRUST_DECLTYPE_RETURNS(
@@ -99,21 +99,26 @@ struct copy_fn final
   static auto call(
     thrust::detail::execution_policy_base<DerivedPolicy> const& exec
   , ForwardIt&& first, Sentinel&& last
-  , OutputIt&& output 
-  ) 
-  // ADL dispatch.
-  THRUST_DECLTYPE_RETURNS(
-    async_copy(
+  , OutputIt&& output
+  )
+//  THRUST_DECLTYPE_RETURNS(
+  { return
+    copy_fn::call(
       thrust::detail::derived_cast(thrust::detail::strip_const(exec))
-    , thrust::detail::derived_cast(thrust::detail::strip_const(exec))
+      // Synthesize a suitable new execution policy, because we don't want to
+      // try and extract twice from the one we were passed.
+    , typename remove_cvref_t<
+        decltype(thrust::detail::derived_cast(thrust::detail::strip_const(exec)))
+      >::tag_type{}
     , THRUST_FWD(first), THRUST_FWD(last)
     , THRUST_FWD(output)
     )
-  )
+    ; }
+//  )
 
   template <typename ForwardIt, typename Sentinel, typename OutputIt>
   __host__
-  static auto call(ForwardIt&& first, Sentinel&& last, OutputIt&& output) 
+  static auto call(ForwardIt&& first, Sentinel&& last, OutputIt&& output)
   THRUST_DECLTYPE_RETURNS(
     copy_fn::call(
       thrust::detail::select_system(

--- a/thrust/detail/event_error.h
+++ b/thrust/detail/event_error.h
@@ -65,7 +65,7 @@ struct event_error_category : error_category
         return "no_state: an operation that requires an event or future to have "
                "a stream or content has been performed on a event or future "
                "without either, e.g. a moved-from or default constructed event "
-               "or future (anevent or future may have been consumed more than "
+               "or future (an event or future may have been consumed more than "
                "once)";
       }
       case event_errc::no_content:
@@ -94,13 +94,13 @@ struct event_error_category : error_category
 
     return system_category().default_error_condition(ev);
   }
-}; 
+};
 
 /// Obtains a reference to the static error category object for the errors
 /// related to futures and promises. The object is required to override the
-/// virtual function error_category::name() to return a pointer to the string 
-/// "event". It is used to identify error codes provided in the 
-/// exceptions of type event_error. 
+/// virtual function error_category::name() to return a pointer to the string
+/// "event". It is used to identify error codes provided in the
+/// exceptions of type event_error.
 inline error_category const& event_category()
 {
   static const event_error_category result;
@@ -123,7 +123,7 @@ inline error_code make_error_code(event_errc e)
 inline error_condition make_error_condition(event_errc e)
 {
   return error_condition(static_cast<int>(e), event_category());
-} 
+}
 
 struct event_error : std::logic_error
 {

--- a/thrust/iterator/detail/any_system_tag.h
+++ b/thrust/iterator/detail/any_system_tag.h
@@ -30,8 +30,5 @@ struct any_system_tag
   template<typename T> operator T () const {return T();}
 };
 
-// TODO remove this in 1.7.0
-typedef THRUST_DEPRECATED any_system_tag any_space_tag;
-
 } // end thrust
 


### PR DESCRIPTION
See #1115 for an explanation.