### PR TITLE
Correct compiler detection logic for Feta in `<thrust/detail/complex/c99math.h>`

### DIFF
--- a/testing/complex_transform.cu
+++ b/testing/complex_transform.cu
@@ -235,15 +235,6 @@ struct TestComplexArithmeticTransform
     thrust::device_vector<type> d_p1 = h_p1;
     thrust::device_vector<type> d_p2 = h_p2;
     thrust::device_vector<type> d_result(n);
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    if(const CUDATestDriver *driver = dynamic_cast<const CUDATestDriver*>(&UnitTestDriver::s_driver()))
-    {
-      if(sizeof(T) == sizeof(double) && driver->current_device_architecture() < 200)
-      {
-        KNOWN_FAILURE;
-      } // end if
-    } // end if
-#endif
 
     thrust::transform(h_p1.begin(), h_p1.end(), h_p2.begin(), h_result.begin(), basic_arithmetic_functor());
     thrust::transform(d_p1.begin(), d_p1.end(), d_p2.begin(), d_result.begin(), basic_arithmetic_functor());    
@@ -263,16 +254,6 @@ struct TestComplexPlaneTransform
 
     thrust::device_vector<type> d_p1 = h_p1;
     thrust::device_vector<type> d_result(n);
-
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    if(const CUDATestDriver *driver = dynamic_cast<const CUDATestDriver*>(&UnitTestDriver::s_driver()))
-    {
-      if(sizeof(T) == sizeof(double) && driver->current_device_architecture() < 200)
-      {
-        KNOWN_FAILURE;
-      } // end if
-    } // end if
-#endif
 
     thrust::transform(h_p1.begin(), h_p1.end(), h_result.begin(), complex_plane_functor());
     thrust::transform(d_p1.begin(), d_p1.end(), d_result.begin(), complex_plane_functor());    
@@ -295,16 +276,6 @@ struct TestComplexPowerTransform
     thrust::device_vector<type> d_p1 = h_p1;
     thrust::device_vector<type> d_p2 = h_p2;
     thrust::device_vector<type> d_result(n);
-
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    if(const CUDATestDriver *driver = dynamic_cast<const CUDATestDriver*>(&UnitTestDriver::s_driver()))
-    {
-      if(sizeof(T) == sizeof(double) && driver->current_device_architecture() < 200)
-      {
-        KNOWN_FAILURE;
-      } // end if
-    } // end if
-#endif
 
     thrust::transform(h_p1.begin(), h_p1.end(), h_p2.begin(), h_result.begin(), pow_functor());
     thrust::transform(d_p1.begin(), d_p1.end(), d_p2.begin(), d_result.begin(), pow_functor());    
@@ -330,16 +301,6 @@ struct TestComplexExponentialTransform
 
     thrust::device_vector<type> d_p1 = h_p1;
     thrust::device_vector<type> d_result(n);
-
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    if(const CUDATestDriver *driver = dynamic_cast<const CUDATestDriver*>(&UnitTestDriver::s_driver()))
-    {
-      if(sizeof(T) == sizeof(double) && driver->current_device_architecture() < 200)
-      {
-        KNOWN_FAILURE;
-      } // end if
-    } // end if
-#endif
 
     thrust::transform(h_p1.begin(), h_p1.end(), h_result.begin(), exp_functor());
     thrust::transform(d_p1.begin(), d_p1.end(), d_result.begin(), exp_functor());    
@@ -368,15 +329,6 @@ struct TestComplexTrigonometricTransform
     thrust::device_vector<type> d_p1 = h_p1;
     thrust::device_vector<type> d_result(n);
 
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    if(const CUDATestDriver *driver = dynamic_cast<const CUDATestDriver*>(&UnitTestDriver::s_driver()))
-    {
-      if(sizeof(T) == sizeof(double) && driver->current_device_architecture() < 200)
-      {
-        KNOWN_FAILURE;
-      } // end if
-    } // end if
-#endif
 
     thrust::transform(h_p1.begin(), h_p1.end(), h_result.begin(), sin_functor());
     thrust::transform(d_p1.begin(), d_p1.end(), d_result.begin(), sin_functor());    
@@ -402,7 +354,6 @@ struct TestComplexTrigonometricTransform
     thrust::transform(h_p1.begin(), h_p1.end(), h_result.begin(), tanh_functor());
     thrust::transform(d_p1.begin(), d_p1.end(), d_result.begin(), tanh_functor());    
     ASSERT_ALMOST_EQUAL(h_result, d_result);
-
 
 
     thrust::transform(h_p1.begin(), h_p1.end(), h_result.begin(), asin_functor());

--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -101,25 +101,15 @@ __host__ __device__ inline int isfinite(double x){
 
 #else
 
-#  if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
-
-// sometimes the CUDA toolkit provides these these names as macros,
-// sometimes functions in the global scope
-
-#    if (CUDART_VERSION >= 6500)
+#  if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__)) && !defined(__NVCOMPILER_CUDA__)
+// NVCC implements at least some signature of these as functions not macros.
 using ::isinf;
 using ::isnan;
 using ::signbit;
 using ::isfinite;
-
-#    else
-// these names are macros, we don't need to define them
-
-#    endif // CUDART_VERSION
-
 #  else
-// Some compilers do not provide these in the global scope
-// they are in std:: instead
+// Some compilers do not provide these in the global scope, because they are
+// supposed to be macros. The versions in `std` are supposed to be functions.
 // Since we're not compiling with nvcc, it's safe to use the functions in std::
 using std::isinf;
 using std::isnan;


### PR DESCRIPTION
Unlike NVCC, it doesn't provide function versions of the C99 math macros and is
not prohibited from using the C++ version of those macros, which are actually
guranteed to be functions. This fixes breakage when Feta is using libstdc++
4.8.5 as its base standard library.