### PR TITLE
Add a unit test for the convenient caching allocator in detail.

### DIFF
--- a/testing/caching_allocator.cu
+++ b/testing/caching_allocator.cu
@@ -1,0 +1,23 @@
+#include <unittest/unittest.h>
+
+#include <thrust/detail/config.h>
+#include <thrust/detail/caching_allocator.h>
+
+template<typename Allocator>
+void test_implementation(Allocator alloc)
+{
+    typedef typename thrust::detail::allocator_traits<Allocator> Traits;
+    typedef typename Allocator::pointer Ptr;
+
+    Ptr p = Traits::allocate(alloc, 123);
+    Traits::deallocate(alloc, p, 123);
+
+    Ptr p2 = Traits::allocate(alloc, 123);
+    ASSERT_EQUAL(p, p2);
+}
+
+void TestSingleDeviceTLSCachingAllocator()
+{
+    test_implementation(thrust::detail::single_device_tls_caching_allocator());
+};
+DECLARE_UNITTEST(TestSingleDeviceTLSCachingAllocator);


### PR DESCRIPTION
Internal shelved CL: 28381691. CI running.

I was trying to figure out if this test can be cleverer in any way, but haven't figured out a good way to do that. The template is there just so that I don't have to utter the actual allocator type there; we can clean that up to just use `auto` once we actually drop C++03.