### PR TITLE
Fix "namespace uses itself"

### DIFF
--- a/thrust/iterator/detail/iterator_category_to_traversal.h
+++ b/thrust/iterator/detail/iterator_category_to_traversal.h
@@ -32,9 +32,6 @@ namespace detail
 template <typename> struct is_iterator_system;
 template <typename> struct is_iterator_traversal;
 
-// make type_traits easy to access
-using namespace thrust::detail;
-
 template <typename Category>
   struct host_system_category_to_traversal
     : eval_if<


### PR DESCRIPTION
iterator_category_to_traversal.h(36): warning C4515: 'detail':
  namespace uses itself


No need to bring the `thrust::detail` namespace into `thrust::detail`.