### PR TITLE
Add a missing inline to the caching allocator accessor.

### DIFF
--- a/thrust/detail/caching_allocator.h
+++ b/thrust/detail/caching_allocator.h
@@ -25,6 +25,7 @@ namespace thrust
 {
 namespace detail
 {
+inline
 thrust::mr::allocator<
     char,
     thrust::mr::disjoint_unsynchronized_pool_resource<


### PR DESCRIPTION
Closes #1149.
