### PR TITLE
Use placement new to construct item on uninitialized memory.

### DIFF
--- a/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/system/cuda/detail/copy_if.h
@@ -255,7 +255,7 @@ namespace __copy_if {
                                      num_selections_prefix;
           if (selection_flags[ITEM])
           {
-            storage.raw_exchange[local_scatter_offset] = items[ITEM];
+            new (&storage.raw_exchange[local_scatter_offset]) item_type(items[ITEM]);
           }
         }
 


### PR DESCRIPTION
Formerly used the assignment operator to copy to uninitialized
memory. But a non-trivial assignment operator requires the destination
object be in a valid state. So use placement new to construct the item
on the uninitialized bits.

Partial fix for #1153
Also a similar fix to come in CUB.