### PR TITLE
Fix compilation  for clang cuda compiler

### DIFF
--- a/testing/event.cu
+++ b/testing/event.cu
@@ -58,8 +58,6 @@ void test_event_new_stream()
 {
   auto e0 = thrust::device_event(thrust::new_stream);
 
-  auto e0_stream = e0.stream().native_handle();
-
   ASSERT_EQUAL(true, e0.valid_stream());
 
   ASSERT_NOT_EQUAL_QUIET(nullptr, e0.stream().native_handle());    

--- a/testing/future.cu
+++ b/testing/future.cu
@@ -102,8 +102,6 @@ struct test_future_new_stream
   {
     auto f0 = thrust::device_future<T>(thrust::new_stream);
 
-    auto f0_stream = f0.stream().native_handle();
-
     ASSERT_EQUAL(true,  f0.valid_stream());
     ASSERT_EQUAL(false, f0.valid_content());
 

--- a/testing/uninitialized_fill.cu
+++ b/testing/uninitialized_fill.cu
@@ -147,6 +147,7 @@ DECLARE_VECTOR_UNITTEST(TestUninitializedFillPOD);
 
 struct CopyConstructTest
 {
+  __host__ __device__
   CopyConstructTest(void)
     :copy_constructed_on_host(false),
      copy_constructed_on_device(false)

--- a/testing/unittest/runtime_static_assert.h
+++ b/testing/unittest/runtime_static_assert.h
@@ -72,6 +72,9 @@ namespace unittest
 
     namespace detail
     {
+#ifdef __clang__
+        __attribute__((used))
+#endif
         __device__ static static_assert_exception* device_exception = NULL;
     }
 


### PR DESCRIPTION
Few minor changes in test code to make tests work with clang as a device compiler.