### PR TITLE
Make out_of_memory_recovery test trigger OOM faster.

### DIFF
--- a/testing/out_of_memory_recovery.cu
+++ b/testing/out_of_memory_recovery.cu
@@ -1,4 +1,14 @@
 // Regression test for NVBug 2720132.
+//
+// Summary of 2720132:
+//
+// 1. The large allocation fails due to running out of memory.
+// 2. A `thrust::system::system_error` exception is thrown.
+// 3. Local objects are destroyed as the stack is unwound, leading to the destruction of `x`.
+// 4. `x` runs a parallel algorithm in its destructor to call the destructors of all of its elements.
+// 5. Launching that parallel algorithm fails because of the prior CUDA out of memory error.
+// 6. A `thrust::system::system_error` exception is thrown.
+// 7. Because we've already got an active exception, `terminate` is called.
 
 #include <unittest/unittest.h>
 #include <thrust/device_vector.h>
@@ -16,8 +26,7 @@ void test_out_of_memory_recovery()
   {
     thrust::device_vector<non_trivial> x(1);
 
-    for (thrust::detail::uint64_t n = 1 ;; n <<= 1)
-      thrust::device_vector<thrust::detail::uint32_t> y(n);
+    thrust::device_vector<thrust::detail::uint32_t> y(0x00ffffffffffffff);
   }
   catch (...) { }
 }


### PR DESCRIPTION
Fixes #1183. This test is taking up the majority of the test
runtime on CPU backends, slowing eating away at RAM/swap for
two minutes while the rest of the system gets evicted from RAM
and stops responding.

Replaced the allocation loop with a single large allocation,
now the test runs in ~1ms and doesn't actually allocate
significant resources.