### PR TITLE
Create wrapper to use when including <algorithm> and <memory>

### DIFF
--- a/thrust/addressof.h
+++ b/thrust/addressof.h
@@ -8,7 +8,7 @@
 #include <thrust/detail/config.h>
 
 #if THRUST_CPP_DIALECT >= 2011
-#  include <memory>
+#  include <thrust/detail/memory_wrapper.h>
 #endif
 
 namespace thrust

--- a/thrust/detail/algorithm_wrapper.h
+++ b/thrust/detail/algorithm_wrapper.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2020 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+// When a compiler uses Thrust as part of its implementation of Standard C++
+// algorithms, a cycle of included files may result when Thrust code tries to
+// use a standard algorithm.  Having a macro that is defined only when Thrust
+// is including an algorithms-related header gives the compiler a chance to
+// detect and break the cycle of includes.
+
+#define THRUST_INCLUDING_ALGORITHMS_HEADER
+#include <algorithm>
+#undef  THRUST_INCLUDING_ALGORITHMS_HEADER

--- a/thrust/detail/allocator/copy_construct_range.inl
+++ b/thrust/detail/allocator/copy_construct_range.inl
@@ -24,7 +24,7 @@
 #include <thrust/distance.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/for_each.h>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 
 namespace thrust
 {

--- a/thrust/detail/allocator/destroy_range.inl
+++ b/thrust/detail/allocator/destroy_range.inl
@@ -18,7 +18,7 @@
 #include <thrust/detail/allocator/allocator_traits.h>
 #include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/for_each.h>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 
 namespace thrust
 {

--- a/thrust/detail/allocator/fill_construct_range.inl
+++ b/thrust/detail/allocator/fill_construct_range.inl
@@ -20,7 +20,7 @@
 #include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/for_each.h>
 #include <thrust/uninitialized_fill.h>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 
 namespace thrust
 {

--- a/thrust/detail/internal_functional.h
+++ b/thrust/detail/internal_functional.h
@@ -27,7 +27,7 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/detail/tuple_of_iterator_references.h>
 #include <thrust/detail/raw_reference_cast.h>
-#include <memory> // for ::new
+#include <thrust/detail/memory_wrapper.h> // for ::new
 
 namespace thrust
 {

--- a/thrust/detail/memory_algorithms.h
+++ b/thrust/detail/memory_algorithms.h
@@ -16,7 +16,7 @@
 
 #include <utility>
 #include <new>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 
 namespace thrust
 {

--- a/thrust/detail/memory_wrapper.h
+++ b/thrust/detail/memory_wrapper.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2020 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+// When a compiler uses Thrust as part of its implementation of Standard C++
+// algorithms, a cycle of included files may result when Thrust code tries to
+// use a standard algorithm.  Having a macro that is defined only when Thrust
+// is including an algorithms-related header gives the compiler a chance to
+// detect and break the cycle of includes.  (<memory> declares several standard
+// algorithms, including all of the uninitialized_* algorithms.  "_ALGORITHMS_"
+// in the macro name is meant generically, not as a specific reference to
+// the header <algorithms>.)
+
+#define THRUST_INCLUDING_ALGORITHMS_HEADER
+#include <memory>
+#undef  THRUST_INCLUDING_ALGORITHMS_HEADER

--- a/thrust/detail/temporary_array.h
+++ b/thrust/detail/temporary_array.h
@@ -39,7 +39,7 @@ template<typename T, typename System>
 #include <thrust/detail/contiguous_storage.h>
 #include <thrust/detail/allocator/temporary_allocator.h>
 #include <thrust/detail/allocator/no_throw_allocator.h>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 
 namespace thrust
 {

--- a/thrust/host_vector.h
+++ b/thrust/host_vector.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <thrust/detail/config.h>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 #include <thrust/detail/vector_base.h>
 #include <vector>
 #include <utility>

--- a/thrust/mr/disjoint_pool.h
+++ b/thrust/mr/disjoint_pool.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <algorithm>
+#include <thrust/detail/algorithm_wrapper.h>
 
 #include <thrust/host_vector.h>
 #include <thrust/binary_search.h>

--- a/thrust/mr/pool.h
+++ b/thrust/mr/pool.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <algorithm>
+#include <thrust/detail/algorithm_wrapper.h>
 
 #include <thrust/host_vector.h>
 

--- a/thrust/system/cuda/detail/future.inl
+++ b/thrust/system/cuda/detail/future.inl
@@ -30,7 +30,7 @@
 #include <thrust/system/cuda/detail/get_value.h>
 
 #include <type_traits>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 
 namespace thrust
 {


### PR DESCRIPTION
Accommodate compilers that use Thrust in their implementations of
C++ Standard algorithms.  To avoid cycles of include files, the
compiler needs to know when an include of an algorithms-related header
(`<algorithm>`, `<numeric>`, or `<memory>`) is coming from Thrust vs from
user code.  Create wrapper files to use when including `<algorithm>` or
`<memory>` that defines a macro that the compiler can check to know
where the include is coming from.  Change all includes of those files
within Thrust code to include the wrapper file instead.  (The same
change would also be made for `<numeric>` if Thrust files included
`<numeric>` anywhere.)

Fix #1218