### PR TITLE
Fix C++17 targets in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
+
+# Remove this when we use the new CUDA_ARCHITECTURES properties:
+cmake_policy(SET CMP0104 OLD)
 
 project(Thrust NONE)
 
@@ -77,8 +80,6 @@ endif ()
 # Temporary hacks to make Feta work; this requires you to define
 # `CMAKE_CUDA_COMPILER_ID=Feta` and `CMAKE_CUDA_COMPILER_FORCED`.
 if ("Feta" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
-  cmake_minimum_required(VERSION 3.17)
-
   set(CMAKE_CUDA_STANDARD_DEFAULT 03)
 
   set(CMAKE_CUDA03_STANDARD_COMPILE_OPTION "-std=c++03")


### PR DESCRIPTION
CMake doesn't recognize CUDA_STANDARD=17 until v3.18, and the
CUDA_STANDARD_REQUIRED property doesn't seem to work properly. See
CMake bug: https://gitlab.kitware.com/cmake/cmake/-/issues/20953

To allow the C++17 configs to actually use C++17, we need to bump our
minimum CMake version to 3.18.

Accompanies thrust/cub#45.

CMake 3.18 can be downloaded here: https://cmake.org/download/
Or via the kitware apt repository as documented here: https://apt.kitware.com/