### PR TITLE
Include <thrust/detail/memory_wrapper.h>, not <memory>

### DIFF
--- a/thrust/allocate_unique.h
+++ b/thrust/allocate_unique.h
@@ -16,7 +16,7 @@
 #include <thrust/detail/allocator/allocator_traits.h>
 
 #include <utility>
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 
 namespace thrust
 {

--- a/thrust/detail/allocator/allocator_traits.inl
+++ b/thrust/detail/allocator/allocator_traits.inl
@@ -23,7 +23,7 @@
   #include <thrust/detail/type_deduction.h>
 #endif
 
-#include <memory>
+#include <thrust/detail/memory_wrapper.h>
 #include <new>
 
 namespace thrust


### PR DESCRIPTION
Redo an earlier fix, which was somehow lost.  Fix #1236