### PR TITLE
Be more conservative with CMake version requirements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
-cmake_minimum_required(VERSION 3.18)
+# 3.15 is the minimum.
+# 3.17 for nvc++/Feta
+# 3.18 for C++17 + CUDA
+cmake_minimum_required(VERSION 3.15)
 
-# Remove this when we use the new CUDA_ARCHITECTURES properties:
-cmake_policy(SET CMP0104 OLD)
+# Remove this when we use the new CUDA_ARCHITECTURES properties with both
+# nvcc and nvc++.
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+  cmake_policy(SET CMP0104 OLD)
+endif()
 
 project(Thrust NONE)
 
@@ -80,6 +86,9 @@ endif ()
 # Temporary hacks to make Feta work; this requires you to define
 # `CMAKE_CUDA_COMPILER_ID=Feta` and `CMAKE_CUDA_COMPILER_FORCED`.
 if ("Feta" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
+  # Need 3.17 for the properties used below.
+  cmake_minimum_required(VERSION 3.17)
+
   set(CMAKE_CUDA_STANDARD_DEFAULT 03)
 
   set(CMAKE_CUDA03_STANDARD_COMPILE_OPTION "-std=c++03")

--- a/cmake/ThrustMultiConfig.cmake
+++ b/cmake/ThrustMultiConfig.cmake
@@ -40,6 +40,12 @@ function(thrust_configure_multiconfig)
     option(THRUST_MULTICONFIG_ENABLE_SYSTEM_OMP "Generate build configurations that use OpenMP." OFF)
     option(THRUST_MULTICONFIG_ENABLE_SYSTEM_TBB "Generate build configurations that use TBB." OFF)
 
+    # CMake added C++17 support for CUDA targets in 3.18:
+    if (THRUST_MULTICONFIG_ENABLE_DIALECT_CPP17 AND
+        THRUST_MULTICONFIG_ENABLE_SYSTEM_CUDA)
+      cmake_minimum_required(VERSION 3.18)
+    endif()
+
     # Workload:
     # - `SMALL`: [3 configs] Minimal coverage and validation of each device system against the `CPP` host.
     # - `MEDIUM`: [6 configs] Cheap extended coverage.
@@ -111,5 +117,11 @@ function(thrust_configure_multiconfig)
       PROPERTY STRINGS
       ${THRUST_CPP_DIALECT_OPTIONS}
     )
+
+    # CMake added C++17 support for CUDA targets in 3.18:
+    if (THRUST_CPP_DIALECT EQUAL 17 AND
+        THRUST_DEVICE_SYSTEM STREQUAL "CUDA")
+      cmake_minimum_required(VERSION 3.18)
+    endif()
   endif()
 endfunction()


### PR DESCRIPTION
3.15 is the minimum.
3.17 for nvc++/Feta.
3.18 for C++17 + CUDA.