### PR TITLE
Add CMake install rules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(cmake/AppendOptionIfAvailable.cmake)
 include(cmake/ThrustBuildCompilerTargets.cmake)
 include(cmake/ThrustBuildTargetList.cmake)
 include(cmake/ThrustMultiConfig.cmake)
+include(cmake/ThrustInstallRules.cmake)
 include(cmake/ThrustUtilities.cmake)
 
 # Add cache string options for CMAKE_BUILD_TYPE and default to RelWithDebInfo.

--- a/cmake/ThrustInstallRules.cmake
+++ b/cmake/ThrustInstallRules.cmake
@@ -1,0 +1,25 @@
+# Thrust is a header library; no need to build anything before installing:
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
+
+install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust"
+  TYPE INCLUDE
+  FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.inl"
+    PATTERN "*.cmake"
+    PATTERN "*.md"
+)
+
+# Depending on how Thrust is configured, CUB's CMake scripts may or may not be
+# included, so maintain a set of CUB install rules in both projects. By default
+# CUB headers are installed alongside Thrust -- this may be disabled by turning
+# off THRUST_INSTALL_CUB_HEADERS.
+option(THRUST_INSTALL_CUB_HEADERS "Include cub headers when installing." ON)
+if (THRUST_INSTALL_CUB_HEADERS)
+  install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub"
+    TYPE INCLUDE
+    FILES_MATCHING
+      PATTERN "*.cuh"
+      PATTERN "*.cmake"
+  )
+endif()


### PR DESCRIPTION
This addresses thrust/thrust#1210.

Requires thrust/cub#49.