### PR TITLE
Restore some THRUST_DECLTYPE_RETURNS macros in async test implementations

### DIFF
--- a/testing/async_reduce.cu
+++ b/testing/async_reduce.cu
@@ -48,7 +48,7 @@ struct custom_plus
     auto operator()(                                                          \
       ForwardIt&& first, Sentinel&& last                                      \
     )                                                                         \
-    THRUST_RETURNS(                                                           \
+    THRUST_DECLTYPE_RETURNS(                                                  \
       ::thrust::async::reduce(                                                \
         __VA_ARGS__                                                           \
       )                                                                       \

--- a/testing/async_reduce_into.cu
+++ b/testing/async_reduce_into.cu
@@ -49,7 +49,7 @@ struct custom_plus
     auto operator()(                                                          \
       ForwardIt&& first, Sentinel&& last, OutputIt&& output                   \
     )                                                                         \
-    THRUST_RETURNS(                                                           \
+    THRUST_DECLTYPE_RETURNS(                                                  \
       ::thrust::async::reduce_into(                                           \
         __VA_ARGS__                                                           \
       )                                                                       \

--- a/testing/async_transform.cu
+++ b/testing/async_transform.cu
@@ -48,7 +48,7 @@ struct divide_by_2
       ForwardIt&& first, Sentinel&& last, OutputIt&& output                   \
     , UnaryOperation&& op                                                     \
     )                                                                         \
-    THRUST_RETURNS(                                                           \
+    THRUST_DECLTYPE_RETURNS(                                                  \
       ::thrust::async::transform(                                             \
         __VA_ARGS__                                                           \
       )                                                                       \


### PR DESCRIPTION
This partially reverts 7ff227ae12a927ba9aa62f216f658c939d21785 and
fixes #1250.

I'm not sure why changing these broke the tests, but since these
usages are just testing details that are being refactored by #1251
let's just revert the change for now.

The test failures were only happening on GCC, MSVC was fine with both
versions of these functions, so it may be a compiler issue.