### PR TITLE
reduce cudaDeviceSynchronize calls

### DIFF
--- a/thrust/system/cuda/detail/par.h
+++ b/thrust/system/cuda/detail/par.h
@@ -69,31 +69,6 @@ private:
   {
     return exec.stream;
   }
-
-  friend __host__ __device__
-  cudaError_t
-  synchronize_stream(execute_on_stream_base &exec)
-  {
-    cudaError_t result;
-    if (THRUST_IS_HOST_CODE) {
-      #if THRUST_INCLUDE_HOST_CODE
-        cudaStreamSynchronize(exec.stream);
-        result = cudaGetLastError();
-      #endif
-    } else {
-      #if THRUST_INCLUDE_DEVICE_CODE
-        #if __THRUST_HAS_CUDART__
-          THRUST_UNUSED_VAR(exec);
-          cudaDeviceSynchronize();
-          result = cudaGetLastError();
-        #else
-          THRUST_UNUSED_VAR(exec);
-          result = cudaSuccess;
-        #endif
-      #endif
-    }
-    return result;
-  }
 };
 
 struct execute_on_stream : execute_on_stream_base<execute_on_stream>


### PR DESCRIPTION
While profiling RAPIDS cuDF applications, I saw a lot of `cudaDeviceSynchronize` calls, which may be detrimental to multi-threaded clients using per-thread default stream. It seems to be a bug to be making these calls. This PR simply moves the logic in `execute_on_stream_base` to the base entry point so that all callers can benefit. With this change I no longer see `cudaDeviceSynchronize` calls in the application I'm profiling.

All tests passed locally.

@brycelelbach @allisonvacanti 