### PR TITLE
Ensure the CUDA radix sort backend synchronizes before returning

### DIFF
--- a/thrust/system/cuda/detail/sort.h
+++ b/thrust/system/cuda/detail/sort.h
@@ -1598,6 +1598,10 @@ namespace __smart_sort {
     {
       cuda_cub::copy(policy, keys.begin(), keys.end(), keys_first);
     }
+
+    cuda_cub::throw_on_error(
+      cuda_cub::synchronize(policy),
+      "merge_sort: failed to synchronize");
   }
 }    // namespace __smart_sort
 


### PR DESCRIPTION
Ensure the CUDA radix sort backend synchronizes before returning. Otherwise, copies from temporary storage will race with destruction of said temporary storage.

NVC++ FS #28463