### PR TITLE
Evaluate CUDA_CUB_RET_IF_FAIL macro argument only once

### DIFF
--- a/thrust/system/cuda/detail/core/util.h
+++ b/thrust/system/cuda/detail/core/util.h
@@ -652,7 +652,10 @@ namespace core {
   }
 
 #define CUDA_CUB_RET_IF_FAIL(e) \
-  if (cub::Debug((e), __FILE__, __LINE__)) return e;
+  do {                          \
+    auto const error = (e);     \
+    if (cub::Debug(error, __FILE__, __LINE__)) return error; \
+  } while(0);
 
   // uninitialized
   // -------

--- a/thrust/system/cuda/detail/core/util.h
+++ b/thrust/system/cuda/detail/core/util.h
@@ -652,10 +652,10 @@ namespace core {
   }
 
 #define CUDA_CUB_RET_IF_FAIL(e) \
-  do {                          \
+  {                             \
     auto const error = (e);     \
     if (cub::Debug(error, __FILE__, __LINE__)) return error; \
-  } while(0);
+  }
 
   // uninitialized
   // -------


### PR DESCRIPTION
This updates the `CUDA_CUB_RET_IF_FAIL` macro to only evaluate its argument once.  Without this, it can silently suppress CUDA errors in many places in the Thrust code that call it like this: `CUDA_CUB_RET_IF_FAIL(cudaPeekAtLastError());`.

The macro calls `cub::Debug` which in some versions of cub will unconditionally clear the CUDA error.  Therefore when it evaluates `cudaPeekAtLastError()` the second time as the return argument, it will return `cudaSuccess` because the last error was just cleared.  Thus any pending CUDA error before this macro was called with `cudaPeekAtLastErrror()` as the argument will be silently dropped.