### PR TITLE
Fix ambiguous overload when using partition with STL containers

### DIFF
--- a/thrust/system/detail/sequential/partition.h
+++ b/thrust/system/detail/sequential/partition.h
@@ -95,7 +95,8 @@ __host__ __device__
   {
     if(wrapped_pred(*next))
     {
-      iter_swap(first, next);
+      // Fully qualify name to disambiguate overloads found via ADL.
+      ::thrust::system::detail::sequential::iter_swap(first, next);
       ++first;
     }
   }
@@ -143,7 +144,8 @@ __host__ __device__
   {
     if(wrapped_pred(*stencil_first))
     {
-      iter_swap(first, next);
+      // Fully qualify name to disambiguate overloads found via ADL.
+      ::thrust::system::detail::sequential::iter_swap(first, next);
       ++first;
     }
 


### PR DESCRIPTION
This fixes the error:
```
error: more than one instance of overloaded function "thrust::system::detail::sequential::iter_swap" matches the argument list:
```

When, e.g., using STL containers with `thrust::partition`. Such as in this example: https://www.godbolt.org/z/dfsn6f

This fix has been proposed by @dkolsen-pgi. Many thanks!