### PR TITLE
Add CMake support for building from NVIDIA's internal p4 depot.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,5 +120,8 @@ endif()
 
 if (THRUST_INCLUDE_CUB_CMAKE AND THRUST_CUDA_FOUND)
   set(CUB_IN_THRUST ON)
-  add_subdirectory(dependencies/cub)
+  # CUB's path is specified generically to support both GitHub and Perforce
+  # source tree layouts. The include directory used by cub-config.cmake
+  # for source layouts is the same as the project root.
+  add_subdirectory("${_CUB_INCLUDE_DIR}" dependencies/cub)
 endif()

--- a/thrust/cmake/thrust-config.cmake
+++ b/thrust/cmake/thrust-config.cmake
@@ -502,7 +502,8 @@ macro(_thrust_find_CUDA required)
       ${required}
       NO_DEFAULT_PATH # Only check the explicit HINTS below:
       HINTS
-        "${_THRUST_INCLUDE_DIR}/dependencies/cub" # Source layout
+        "${_THRUST_INCLUDE_DIR}/dependencies/cub" # Source layout (GitHub)
+        "${_THRUST_INCLUDE_DIR}/../cub/cub/cmake" # Source layout (Perforce)
         "${_THRUST_CMAKE_DIR}/.."                 # Install layout
     )
 


### PR DESCRIPTION
gpgpu's source layout places the Thrust and CUB project roots as
siblings, rather than a nested subdirectory. These changes accomodate
that layout.