### PR TITLE
update type_traits/logical_metafunctions.h #1547

### DIFF
--- a/thrust/type_traits/logical_metafunctions.h
+++ b/thrust/type_traits/logical_metafunctions.h
@@ -131,9 +131,9 @@ struct conjunction_value<> : std::true_type {};
 template <bool B>
 struct conjunction_value<B> : std::integral_constant<bool, B> {};
 
-template <bool B0, bool... BN>
-struct conjunction_value<B0, BN...>
-  : std::integral_constant<bool, B0 && conjunction_value<BN...>::value> {};
+template <bool B, bool... Bs>
+struct conjunction_value<B, Bs...>
+  : std::integral_constant<bool, B && conjunction_value<Bs...>::value> {};
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -153,9 +153,9 @@ struct disjunction_value<> : std::false_type {};
 template <bool B>
 struct disjunction_value<B> : std::integral_constant<bool, B> {};
 
-template <bool B0, bool... BN>
-struct disjunction_value<B0, BN...>
-  : std::integral_constant<bool, B0 || disjunction_value<BN...>::value> {};
+template <bool B, bool... Bs>
+struct disjunction_value<B, Bs...>
+  : std::integral_constant<bool, B || disjunction_value<Bs...>::value> {};
 
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This is to avoid namespace conflict with termios.h definition of macro "B0"