### PR TITLE
Reference CUDA back end functions only when CUDA back end is enabled

### DIFF
--- a/thrust/detail/allocator/temporary_allocator.inl
+++ b/thrust/detail/allocator/temporary_allocator.inl
@@ -50,11 +50,15 @@ __host__ __device__
     // note that we pass cnt to deallocate, not a value derived from result.second
     deallocate(result.first, cnt);
 
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     NV_IF_TARGET(NV_IS_HOST, (
       throw thrust::system::detail::bad_alloc("temporary_buffer::allocate: get_temporary_buffer failed");
     ), ( // NV_IS_DEVICE
       thrust::system::cuda::detail::terminate_with_message("temporary_buffer::allocate: get_temporary_buffer failed");
     ));
+#else
+    throw thrust::system::detail::bad_alloc("temporary_buffer::allocate: get_temporary_buffer failed");
+#endif
   } // end if
 
   return result.first;


### PR DESCRIPTION
Add a `#if` block to `temporary_allocator<T,S>::allocate` in
`thrust/detail/allocator/temporary_allocator.inl` so that the CUDA back end
function `thrust::system::cuda::detail::terminate_with_message` is referenced
only when the CUDA back end is enabled.  Putting the reference within the
device-specific branch of an `NV_IF_TARGET` isn't good enough; there are some
situations, e.g. `nvc++ -cuda -stdpar=multicore`, where that doesn't work
and an explicit check for the CUDA back end is necessary.