### PR TITLE
Enable construction of vectors from `std::initializer_list`

### DIFF
--- a/testing/vector.cu
+++ b/testing/vector.cu
@@ -40,7 +40,6 @@ void TestVectorBool(void)
 }
 DECLARE_UNITTEST(TestVectorBool);
 
-#if THRUST_CPP_DIALECT >= 2011
 template <class Vector>
 void TestVectorInitializerList(void)
 {
@@ -65,7 +64,6 @@ void TestVectorInitializerList(void)
     ASSERT_EQUAL(v2[2], 3);
 }
 DECLARE_VECTOR_UNITTEST(TestVectorInitializerList);
-#endif
 
 template <class Vector>
 void TestVectorFrontBack(void)

--- a/thrust/detail/vector_base.h
+++ b/thrust/detail/vector_base.h
@@ -29,9 +29,7 @@
 #include <thrust/detail/config.h>
 #include <thrust/detail/contiguous_storage.h>
 
-#if THRUST_CPP_DIALECT >= 2011
 #include <initializer_list>
-#endif
 #include <vector>
 
 THRUST_NAMESPACE_BEGIN
@@ -127,7 +125,6 @@ template<typename T, typename Alloc>
      */
     vector_base &operator=(const vector_base &v);
 
-  #if THRUST_CPP_DIALECT >= 2011
     /*! Move assign operator moves from another vector_base.
      *  \param v The vector_base to move.
      */
@@ -148,7 +145,6 @@ template<typename T, typename Alloc>
      *  \param il The initializer_list.
      */
     vector_base &operator=(std::initializer_list<T> il);
-  #endif
 
     /*! Copy constructor copies from an exemplar vector_base with different
      *  type.

--- a/thrust/detail/vector_base.inl
+++ b/thrust/detail/vector_base.inl
@@ -195,7 +195,6 @@ template<typename T, typename Alloc>
   return *this;
 } // end vector_base::operator=()
 
-#if THRUST_CPP_DIALECT >= 2011
   template<typename T, typename Alloc>
     vector_base<T,Alloc>
       ::vector_base(std::initializer_list<T> il)
@@ -223,7 +222,6 @@ template<typename T, typename Alloc>
 
     return *this;
   } // end vector_base::operator=()
-#endif
 
 template<typename T, typename Alloc>
   template<typename IteratorOrIntegralType>

--- a/thrust/device_vector.h
+++ b/thrust/device_vector.h
@@ -26,9 +26,7 @@
 #include <thrust/detail/vector_base.h>
 #include <thrust/device_allocator.h>
 
-#if THRUST_CPP_DIALECT >= 2011
 #include <initializer_list>
-#endif
 #include <vector>
 #include <utility>
 
@@ -200,26 +198,24 @@ template<typename T, typename Alloc = thrust::device_allocator<T> >
     device_vector &operator=(const detail::vector_base<OtherT,OtherAlloc> &v)
     { Parent::operator=(v); return *this; }
 
-#if THRUST_CPP_DIALECT >= 2011
     /*! This constructor builds a \p device_vector from an intializer_list.
      *  \param il The intializer_list.
      */
     device_vector(std::initializer_list<T> il)
-      :Parent(il.begin(), il.end()) {}
+      :Parent(il) {}
       
     /*! This constructor builds a \p device_vector from an intializer_list.
      *  \param il The intializer_list.
      *  \param alloc The allocator to use by this device_vector.
      */
     device_vector(std::initializer_list<T> il, const Alloc &alloc)
-      :Parent(il.begin(), il.end(), alloc) {}
+      :Parent(il, alloc) {}
       
     /*! Assign an \p intializer_list with a matching element type
      *  \param il The intializer_list.
      */
     device_vector &operator=(std::initializer_list<T> il)
     { Parent::operator=(il); return *this; }
-#endif
 
     /*! This constructor builds a \p device_vector from a range.
      *  \param first The beginning of the range.

--- a/thrust/host_vector.h
+++ b/thrust/host_vector.h
@@ -26,9 +26,7 @@
 #include <thrust/detail/memory_wrapper.h>
 #include <thrust/detail/vector_base.h>
 
-#if THRUST_CPP_DIALECT >= 2011
 #include <initializer_list>
-#endif
 #include <vector>
 #include <utility>
 
@@ -221,26 +219,24 @@ template<typename T, typename Alloc = std::allocator<T> >
     host_vector &operator=(const detail::vector_base<OtherT,OtherAlloc> &v)
     { Parent::operator=(v); return *this; }
     
-#if THRUST_CPP_DIALECT >= 2011
     /*! This constructor builds a \p host_vector from an intializer_list.
      *  \param il The intializer_list.
      */
     host_vector(std::initializer_list<T> il)
-      :Parent(il.begin(), il.end()) {}
+      :Parent(il) {}
       
     /*! This constructor builds a \p host_vector from an intializer_list.
      *  \param il The intializer_list.
      *  \param alloc The allocator to use by this host_vector.
      */
     host_vector(std::initializer_list<T> il, const Alloc &alloc)
-      :Parent(il.begin(), il.end(), alloc) {}
+      :Parent(il, alloc) {}
       
     /*! Assign an \p intializer_list with a matching element type
      *  \param il The intializer_list.
      */
     host_vector &operator=(std::initializer_list<T> il)
     { Parent::operator=(il); return *this; }
-#endif
 
     /*! This constructor builds a \p host_vector from a range.
      *  \param first The beginning of the range.

--- a/thrust/system/cpp/detail/vector.inl
+++ b/thrust/system/cpp/detail/vector.inl
@@ -97,6 +97,7 @@ template<typename T, typename Allocator>
     super_t::operator=(std::move(x));
     return *this;
   }
+#endif
   
   template<typename T, typename Allocator>
     vector<T,Allocator>
@@ -118,7 +119,6 @@ template<typename T, typename Allocator>
     super_t::operator=(il);
     return *this;
   }
-#endif
 
 template<typename T, typename Allocator>
   template<typename OtherT, typename OtherAllocator>


### PR DESCRIPTION
This fixes #1835 and enables construction of vectors from an `initializer_list` as well as assignment.