### PR TITLE
:recycle::memo: Update `mode` example to use `thrust::unique_count`

### DIFF
--- a/examples/mode.cu
+++ b/examples/mode.cu
@@ -46,11 +46,7 @@ int main(void)
     std::cout << std::endl;
 
     // count number of unique keys
-    size_t num_unique = thrust::inner_product(d_data.begin(), d_data.end() - 1,
-                                              d_data.begin() + 1,
-                                              0,
-                                              thrust::plus<int>(),
-                                              thrust::not_equal_to<int>()) + 1;
+    size_t num_unique = thrust::unique_count(d_data.begin(), d_data.end());
 
     // count multiplicity of each key
     thrust::device_vector<int> d_output_keys(num_unique);


### PR DESCRIPTION
When this example was created, `thrust::unique_count` did not exist. It was added in 2022 (2 years ago) in this PR: https://github.com/NVIDIA/thrust/issues/1612. It shouldn't definitely be used now.

I noticed this while @brycelelbach and I were chatting about this algorithm while recording an episode of ADSP 😃 